### PR TITLE
Use Authorization header to send access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,9 @@ typings/
 
 # End of https://www.gitignore.io/api/node,macos,intellij,visualstudiocode
 
+### IntelliJ
+*.iml
+
 ## documentation
 docs/
 

--- a/src/Api.ts
+++ b/src/Api.ts
@@ -26,10 +26,7 @@ export default class Api {
   constructor(url: string, options?: ApiOptions) {
     this.options = options || {};
     this.url = url;
-    if (this.options.accessToken) {
-      const accessTokenParam = `access_token=${this.options.accessToken}`;
-      this.url += separator(url) + accessTokenParam;
-    }
+
     if(this.options.routes) {
       this.url += separator(url) + `routes=${encodeURIComponent(JSON.stringify(this.options.routes))}`;
     }
@@ -40,6 +37,7 @@ export default class Api {
       this.options.apiCache,
       this.options.proxyAgent,
       this.options.timeoutInMs,
+      this.options.accessToken,
     );
   }
 

--- a/src/HttpClient.ts
+++ b/src/HttpClient.ts
@@ -8,16 +8,18 @@ export interface HttpClientOptions {
 
 export default class HttpClient {
 
-  private cache: ApiCache;
-  private requestHandler: RequestHandler;
+  private readonly cache: ApiCache;
+  private readonly requestHandler: RequestHandler;
+  private readonly accessToken: string | undefined;
 
-  constructor(requestHandler?: RequestHandler, cache?: ApiCache, proxyAgent?: any, timeoutInMs?: number) {
+  constructor(requestHandler?: RequestHandler, cache?: ApiCache, proxyAgent?: any, timeoutInMs?: number, accessToken?: string) {
     this.requestHandler = requestHandler || new DefaultRequestHandler({ proxyAgent, timeoutInMs });
     this.cache = cache || new DefaultApiCache();
+    this.accessToken = accessToken;
   }
 
   request<T>(url: string, callback?: RequestCallback<T>): void {
-    this.requestHandler.request<T>(url, (err, result, xhr, ttl) => {
+    this.requestHandler.request<T>(url, this.accessToken, (err, result, xhr, ttl) => {
       if (err) {
         callback && callback(err, null, xhr, ttl);
       } else if (result) {

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,11 +4,13 @@ interface NodeRequestInit extends RequestInit {
   agent?: any;
 }
 
-function fetchRequest<T>(url: string, options: RequestHandlerOption, callback: RequestCallback<T>): void {
+function fetchRequest<T>(url: string, options: RequestHandlerOption, accessToken: string | undefined, callback: RequestCallback<T>): void {
 
+  const authorizationHeader = accessToken ? { Authorization: `Token ${accessToken}` } : {};
   const fetchOptions = {
     headers: {
       Accept: 'application/json',
+      ...authorizationHeader
     },
   } as NodeRequestInit;
 
@@ -69,7 +71,8 @@ export interface RequestHandlerOption {
 }
 
 export interface RequestHandler {
-  request<T>(url: string, cb: RequestCallback<T>): void;
+  options: RequestHandlerOption;
+  request<T>(url: string, accessToken: string | undefined, cb: RequestCallback<T>): void;
 }
 
 export class DefaultRequestHandler implements RequestHandler {
@@ -80,8 +83,7 @@ export class DefaultRequestHandler implements RequestHandler {
     this.options = options || {};
   }
 
-  request<T>(url: string, callback: RequestCallback<T>): void {
-
-    fetchRequest(url, this.options, callback);
+  request<T>(url: string, accessToken: string | undefined, callback: RequestCallback<T>): void {
+    fetchRequest(url, this.options, accessToken, callback);
   }
 }

--- a/test/api.js
+++ b/test/api.js
@@ -12,7 +12,7 @@ function fixtures(file) {
 function getApi() {
   var options = {
     requestHandler: {
-      request: function(url, cb) {
+      request: function(url, _, cb) {
         if (url.startsWith('http://localhost:3000/api/v2/documents/search')) {
           cb(null, fixtures('search.json'));
         } else if(url === 'http://localhost:3000/api') {

--- a/test/cache.js
+++ b/test/cache.js
@@ -11,7 +11,7 @@ function fixtures(file) {
 function getClient(opts) {
   var options = {
     requestHandler: {
-      request: function(url, cb) {
+      request: function(url, _, cb) {
         if (url.startsWith('http://localhost:3000/api/v2/documents/search')) {
           var searchJson = fixtures('search.json');
           searchJson.results[0].last_publication_date = Date.now();

--- a/test/prismic.js
+++ b/test/prismic.js
@@ -12,7 +12,7 @@ function fixtures(file) {
 function getClient() {
   var options = {
     requestHandler: {
-      request: function(url, cb) {
+      request: function(url, _, cb) {
         if (url.startsWith('http://localhost:3000/api/v2/documents/search')) {
           cb(null, fixtures('search.json'));
         } else if(url === 'http://localhost:3000/api') {


### PR DESCRIPTION
Instead of using `access_token` query parameter to pass the access token, we now use the Authorization header like that:
```
Authorization: Token MY_SUPER_TOKEN
```
fixes prismicio/issue-tracker-wroom#351