### PR TITLE
feat: use authorization header for access token

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -5,13 +5,7 @@ import { appendPredicates } from "./lib/appendPredicates";
 import { castThunk } from "./lib/castThunk";
 import { getCookie } from "./lib/getCookie";
 
-import {
-	FetchLike,
-	HttpRequestLike,
-	// TODO: Uncomment when the Authorization header can be used
-	// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-	// RequestInitLike
-} from "./types";
+import { FetchLike, HttpRequestLike, RequestInitLike } from "./types";
 import { buildQueryURL, BuildQueryURLArgs } from "./buildQueryURL";
 import { ForbiddenError, isForbiddenErrorAPIResponse } from "./ForbiddenError";
 import { ParsingError, isParsingErrorAPIResponse } from "./ParsingError";
@@ -517,10 +511,7 @@ export class Client {
 	): Promise<prismicT.Query<TDocument>> {
 		const url = await this.buildQueryURL(params);
 
-		// TODO: Uncomment when the Authorization header can be used
-		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-		// return await this.fetch<Query<TDocument>>(url, params);
-		return await this.fetch<prismicT.Query<TDocument>>(url);
+		return await this.fetch<prismicT.Query<TDocument>>(url, params);
 	}
 
 	/**
@@ -980,17 +971,7 @@ export class Client {
 	 * @returns Repository metadata.
 	 */
 	async getRepository(): Promise<prismicT.Repository> {
-		// TODO: Uncomment when the Authorization header can be used
-		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-		// return await this.fetch<Repository>(this.endpoint);
-
-		const url = new URL(this.endpoint);
-
-		if (this.accessToken) {
-			url.searchParams.set("access_token", this.accessToken);
-		}
-
-		return await this.fetch<prismicT.Repository>(url.toString());
+		return await this.fetch<prismicT.Repository>(this.endpoint);
 	}
 
 	/**
@@ -1111,17 +1092,10 @@ export class Client {
 	async buildQueryURL(
 		params: Partial<BuildQueryURLArgs> = {},
 	): Promise<string> {
-		// TODO: Uncomment when the Authorization header can be used
-		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-		// const {
-		// 	ref = await this.getResolvedRefString(),
-		// 	accessToken: _accessToken,
-		// 	...actualParams
-		// } = params;
 		const {
 			ref = await this.getResolvedRefString(),
 			integrationFieldsRef = await this.getResolvedIntegrationFieldsRef(),
-			accessToken = this.accessToken,
+			accessToken: _accessToken,
 			routes = this.routes,
 			...actualParams
 		} = params;
@@ -1129,7 +1103,6 @@ export class Client {
 		return buildQueryURL(this.endpoint, {
 			...this.defaultParams,
 			...actualParams,
-			accessToken,
 			ref,
 			integrationFieldsRef,
 			routes,
@@ -1447,17 +1420,15 @@ export class Client {
 	 * @returns Request options that can be used to make a network request to
 	 *   query the repository.
 	 */
-	// TODO: Uncomment when the Authorization header can be used
-	// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-	// private buildRequestOptions(
-	// 	params?: Partial<BuildQueryURLArgs>
-	// ): RequestInitLike {
-	// 	const accessToken = params?.accessToken || this.accessToken;
+	private buildRequestOptions(
+		params?: Partial<BuildQueryURLArgs>,
+	): RequestInitLike {
+		const accessToken = params?.accessToken || this.accessToken;
 
-	// 	return accessToken
-	// 		? { headers: { Authorization: `Token ${accessToken}` } }
-	// 		: {};
-	// }
+		return accessToken
+			? { headers: { Authorization: `Token ${accessToken}` } }
+			: {};
+	}
 
 	/**
 	 * Performs a network request using the configured `fetch` function. It
@@ -1472,15 +1443,10 @@ export class Client {
 	 */
 	private async fetch<T = unknown>(
 		url: string,
-		// TODO: Uncomment when the Authorization header can be used
-		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-		// params?: Partial<BuildQueryURLArgs>
+		params?: Partial<BuildQueryURLArgs>,
 	): Promise<T> {
-		// TODO: Uncomment when the Authorization header can be used
-		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-		// const options = this.buildRequestOptions(params);
-		// const res = await this.fetchFn(url, options);
-		const res = await this.fetchFn(url);
+		const options = this.buildRequestOptions(params);
+		const res = await this.fetchFn(url, options);
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		let json: any;

--- a/test/__testutils__/createMockQueryHandler.ts
+++ b/test/__testutils__/createMockQueryHandler.ts
@@ -2,12 +2,10 @@ import { SetRequired } from "type-fest";
 import * as ava from "ava";
 import * as msw from "msw";
 import * as crypto from "crypto";
-
-import * as prismic from "../../src";
+import * as prismicT from "@prismicio/types";
 
 import { isValidAccessToken } from "./isValidAccessToken";
 import { createQueryResponse } from "./createQueryResponse";
-import * as prismicT from "@prismicio/types";
 
 const castArray = <A>(a: A | A[]): A[] => (Array.isArray(a) ? a : [a]);
 
@@ -15,7 +13,7 @@ export const createMockQueryHandler = <
 	TDocument extends prismicT.PrismicDocument = prismicT.PrismicDocument,
 >(
 	t: ava.ExecutionContext,
-	pagedResponses: Partial<prismic.Query<SetRequired<TDocument, "uid">>>[] = [
+	pagedResponses: Partial<prismicT.Query<SetRequired<TDocument, "uid">>>[] = [
 		createQueryResponse(),
 	],
 	accessToken?: string,
@@ -60,29 +58,16 @@ export const createMockQueryHandler = <
 				requiredSearchParamsInstance.append("page", page.toString());
 			}
 
-			// TODO: Remove when the Authorization header can be used
-			// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-			const searchParamsWithoutAccessToken = new URLSearchParams(
-				req.url.searchParams,
-			);
-			searchParamsWithoutAccessToken.delete("access_token");
-
 			if (debug) {
 				t.is(
 					requiredSearchParamsInstance.toString(),
-					// TODO: Uncomment when the Authorization header can be used
-					// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-					// req.url.searchParams.toString()
-					searchParamsWithoutAccessToken.toString(),
+					req.url.searchParams.toString(),
 				);
 			}
 
 			requestMatches =
 				requiredSearchParamsInstance.toString() ===
-				// TODO: Uncomment when the Authorization header can be used
-				// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-				// req.url.searchParams.toString()
-				searchParamsWithoutAccessToken.toString();
+				req.url.searchParams.toString();
 		}
 
 		if (requestMatches) {

--- a/test/__testutils__/createQueryResponse.ts
+++ b/test/__testutils__/createQueryResponse.ts
@@ -1,16 +1,14 @@
 import { SetRequired } from "type-fest";
-
-import * as prismic from "../../src";
-import { createDocument } from "./createDocument";
-
 import * as prismicT from "@prismicio/types";
+
+import { createDocument } from "./createDocument";
 
 export const createQueryResponse = <
 	TDocument extends prismicT.PrismicDocument = prismicT.PrismicDocument,
 >(
 	docs: SetRequired<TDocument, "uid">[] = [createDocument(), createDocument()],
-	overrides?: Partial<prismic.Query<TDocument>>,
-): prismic.Query<SetRequired<TDocument, "uid">> => ({
+	overrides?: Partial<prismicT.Query<TDocument>>,
+): prismicT.Query<SetRequired<TDocument, "uid">> => ({
 	page: 1,
 	results_per_page: docs.length,
 	results_size: docs.length,

--- a/test/__testutils__/createQueryResponsePages.ts
+++ b/test/__testutils__/createQueryResponsePages.ts
@@ -1,10 +1,8 @@
 import { SetRequired } from "type-fest";
-
-import * as prismic from "../../src";
+import * as prismicT from "@prismicio/types";
 
 import { createDocument } from "./createDocument";
 import { createQueryResponse } from "./createQueryResponse";
-import * as prismicT from "@prismicio/types";
 
 type CreateQueryResponsePagesArgs<
 	TDocument extends prismicT.PrismicDocument = prismicT.PrismicDocument,
@@ -20,7 +18,7 @@ export const createQueryResponsePages = <
 	numPages = 3,
 	numDocsPerPage = 3,
 	fields,
-}: CreateQueryResponsePagesArgs<TDocument>): prismic.Query<
+}: CreateQueryResponsePagesArgs<TDocument>): prismicT.Query<
 	SetRequired<TDocument, "uid">
 >[] => {
 	const documents = Array(numDocsPerPage)

--- a/test/__testutils__/createRepositoryResponse.ts
+++ b/test/__testutils__/createRepositoryResponse.ts
@@ -1,10 +1,10 @@
-import * as prismic from "../../src";
+import * as prismicT from "@prismicio/types";
 
 import { createRef } from "./createRef";
 
 export const createRepositoryResponse = (
-	overrides?: Partial<prismic.Repository>,
-): prismic.Repository => {
+	overrides?: Partial<prismicT.Repository>,
+): prismicT.Repository => {
 	return {
 		refs: [createRef(true)],
 		integrationFieldsRef: null,

--- a/test/__testutils__/isValidAccessToken.ts
+++ b/test/__testutils__/isValidAccessToken.ts
@@ -1,20 +1,13 @@
 import * as msw from "msw";
 
-// TODO: Uncomment when the Authorization header can be used
-// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-// import { createAuthorizationHeader } from "./createAuthorizationHeader";
+import { createAuthorizationHeader } from "./createAuthorizationHeader";
 
 export const isValidAccessToken = (
 	accessToken: string | undefined,
 	req: msw.RestRequest,
 ): boolean => {
-	// TODO: Uncomment when the Authorization header can be used
-	// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-	// return typeof accessToken === "string"
-	// 	? req.headers.get("Authorization") ===
-	// 			createAuthorizationHeader(accessToken)
-	// 	: true;
 	return typeof accessToken === "string"
-		? req.url.searchParams.get("access_token") === accessToken
+		? req.headers.get("Authorization") ===
+				createAuthorizationHeader(accessToken)
 		: true;
 };

--- a/test/__testutils__/types.ts
+++ b/test/__testutils__/types.ts
@@ -1,6 +1,6 @@
-import { Repository } from "../../src";
+import * as prismicT from "@prismicio/types";
 
 export type GetContext = {
-	repositoryResponse: Repository;
-	getRef(repository: Repository): string;
+	repositoryResponse: prismicT.Repository;
+	getRef(repository: prismicT.Repository): string;
 };

--- a/test/client-buildQueryURL.test.ts
+++ b/test/client-buildQueryURL.test.ts
@@ -42,9 +42,6 @@ test("includes params if provided", async (t) => {
 	const expectedSearchParams = new URLSearchParams({
 		ref: params.ref,
 		lang: params.lang?.toString() ?? "",
-		// TODO: Remove when the Authorization header can be used
-		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-		access_token: params.accessToken ?? "",
 	});
 
 	t.is(url.host, new URL(client.endpoint).host);
@@ -68,9 +65,6 @@ test("includes default params if provided", async (t) => {
 	const expectedSearchParams = new URLSearchParams({
 		ref: clientOptions.ref?.toString() ?? "",
 		lang: clientOptions.defaultParams?.lang?.toString() ?? "",
-		// TODO: Remove when the Authorization header can be used
-		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-		access_token: clientOptions.accessToken ?? "",
 	});
 
 	t.is(url.host, new URL(client.endpoint).host);
@@ -98,9 +92,6 @@ test("merges params and default params if provided", async (t) => {
 		ref: params.ref,
 		lang: clientOptions.defaultParams?.lang?.toString() ?? "",
 		page: clientOptions.defaultParams?.page?.toString() ?? "",
-		// TODO: Remove when the Authorization header can be used
-		// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-		access_token: clientOptions.accessToken ?? "",
 	});
 
 	t.is(url.host, new URL(client.endpoint).host);

--- a/test/client-getRepository.test.ts
+++ b/test/client-getRepository.test.ts
@@ -5,8 +5,6 @@ import { createMockRepositoryHandler } from "./__testutils__/createMockRepositor
 import { createRepositoryResponse } from "./__testutils__/createRepositoryResponse";
 import { createTestClient } from "./__testutils__/createClient";
 
-import * as prismic from "../src";
-
 const server = mswNode.setupServer();
 test.before(() => server.listen({ onUnhandledRequest: "error" }));
 test.after(() => server.close());
@@ -16,22 +14,6 @@ test("returns repository metadata", async (t) => {
 	server.use(createMockRepositoryHandler(t, response));
 
 	const client = createTestClient(t);
-	const res = await client.getRepository();
-
-	t.deepEqual(res, response);
-});
-
-// TODO: Remove when the Authorization header can be used
-// @see Related issue - {@link https://github.com/prismicio/issue-tracker-wroom/issues/351}
-test("includes access token if configured", async (t) => {
-	const options: prismic.ClientConfig = {
-		accessToken: "accessToken",
-	};
-
-	const response = createRepositoryResponse();
-	server.use(createMockRepositoryHandler(t, response, options.accessToken));
-
-	const client = createTestClient(t, options);
 	const res = await client.getRepository();
 
 	t.deepEqual(res, response);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This moves the access token from a URL parameter to the Authorization header. The header is the preferred authorization strategy.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🚙