### PR TITLE
feat: add `getBySomeTags`, rename `getByTags` to `getByEveryTag`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -262,14 +262,26 @@ const typePredicate = (documentType: string): string =>
 	predicate.at("document.type", documentType);
 
 /**
- * Creates a predicate to filter content by document tags.
+ * Creates a predicate to filter content by document tags. All tags are required
+ * on the document.
  *
  * @param documentType - Document tags to filter queried content.
  *
  * @returns A predicate that can be used in a Prismic REST API V2 request.
  */
-const tagsPredicate = (tags: string | string[]): string =>
+const everyTagPredicate = (tags: string | string[]): string =>
 	predicate.at("document.tags", tags);
+
+/**
+ * Creates a predicate to filter content by document tags. At least one matching
+ * tag is required on the document.
+ *
+ * @param documentType - Document tags to filter queried content.
+ *
+ * @returns A predicate that can be used in a Prismic REST API V2 request.
+ */
+const someTagsPredicate = (tags: string | string[]): string =>
+	predicate.any("document.tags", tags);
 
 /**
  * Returns the first ref from a list that passes a predicate (a function that
@@ -884,7 +896,7 @@ export class Client {
 		params?: Partial<BuildQueryURLArgs>,
 	): Promise<prismicT.Query<TDocument>> {
 		return await this.get<TDocument>(
-			appendPredicates(tagsPredicate(tag))(params),
+			appendPredicates(everyTagPredicate(tag))(params),
 		);
 	}
 
@@ -910,57 +922,111 @@ export class Client {
 		params?: Partial<Omit<BuildQueryURLArgs, "page">>,
 	): Promise<TDocument[]> {
 		return await this.getAll<TDocument>(
-			appendPredicates(tagsPredicate(tag))(params),
+			appendPredicates(everyTagPredicate(tag))(params),
 		);
 	}
 
 	/**
-	 * Queries documents from the Prismic repository with a specific tag.
+	 * Queries documents from the Prismic repository with specific tags. A
+	 * document must be tagged with all of the queried tags to be included.
 	 *
 	 * @example
 	 *
 	 * ```ts
-	 * const response = await client.getAllByTag("food");
+	 * const response = await client.getByEveryTag(["food", "fruit"]);
 	 * ```
 	 *
 	 * @typeParam TDocument - Type of Prismic documents returned.
 	 * @param tags - A list of tags that must be included on a document.
 	 * @param params - Parameters to filter, sort, and paginate the results.
 	 *
-	 * @returns A paginated response containing documents with the tag.
+	 * @returns A paginated response containing documents with the tags.
 	 */
-	async getByTags<TDocument extends prismicT.PrismicDocument>(
+	async getByEveryTag<TDocument extends prismicT.PrismicDocument>(
 		tags: string[],
 		params?: Partial<BuildQueryURLArgs>,
 	): Promise<prismicT.Query<TDocument>> {
 		return await this.get<TDocument>(
-			appendPredicates(tagsPredicate(tags))(params),
+			appendPredicates(everyTagPredicate(tags))(params),
 		);
 	}
 
 	/**
-	 * Queries all documents from the Prismic repository with a specific tag.
+	 * Queries documents from the Prismic repository with specific tags. A
+	 * document must be tagged with all of the queried tags to be included.
 	 *
 	 * This method may make multiple network requests to query all matching content.
 	 *
 	 * @example
 	 *
 	 * ```ts
-	 * const response = await client.getAllByTag("food");
+	 * const response = await client.getAllByEveryTag(["food", "fruit"]);
 	 * ```
 	 *
 	 * @typeParam TDocument - Type of Prismic documents returned.
 	 * @param tags - A list of tags that must be included on a document.
 	 * @param params - Parameters to filter, sort, and paginate the results.
 	 *
-	 * @returns A list of all documents with the tag.
+	 * @returns A list of all documents with the tags.
 	 */
-	async getAllByTags<TDocument extends prismicT.PrismicDocument>(
+	async getAllByEveryTag<TDocument extends prismicT.PrismicDocument>(
 		tags: string[],
 		params?: Partial<Omit<BuildQueryURLArgs, "page">>,
 	): Promise<TDocument[]> {
 		return await this.getAll<TDocument>(
-			appendPredicates(tagsPredicate(tags))(params),
+			appendPredicates(everyTagPredicate(tags))(params),
+		);
+	}
+
+	/**
+	 * Queries documents from the Prismic repository with specific tags. A
+	 * document must be tagged with at least one of the queried tags to be included.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * const response = await client.getByEveryTag(["food", "fruit"]);
+	 * ```
+	 *
+	 * @typeParam TDocument - Type of Prismic documents returned.
+	 * @param tags - A list of tags that must be included on a document.
+	 * @param params - Parameters to filter, sort, and paginate the results.
+	 *
+	 * @returns A paginated response containing documents with at least one of the tags.
+	 */
+	async getBySomeTags<TDocument extends prismicT.PrismicDocument>(
+		tags: string[],
+		params?: Partial<BuildQueryURLArgs>,
+	): Promise<prismicT.Query<TDocument>> {
+		return await this.get<TDocument>(
+			appendPredicates(someTagsPredicate(tags))(params),
+		);
+	}
+
+	/**
+	 * Queries documents from the Prismic repository with specific tags. A
+	 * document must be tagged with at least one of the queried tags to be included.
+	 *
+	 * This method may make multiple network requests to query all matching content.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * const response = await client.getAllByEveryTag(["food", "fruit"]);
+	 * ```
+	 *
+	 * @typeParam TDocument - Type of Prismic documents returned.
+	 * @param tags - A list of tags that must be included on a document.
+	 * @param params - Parameters to filter, sort, and paginate the results.
+	 *
+	 * @returns A list of all documents with at least one of the tags.
+	 */
+	async getAllBySomeTags<TDocument extends prismicT.PrismicDocument>(
+		tags: string[],
+		params?: Partial<Omit<BuildQueryURLArgs, "page">>,
+	): Promise<TDocument[]> {
+		return await this.getAll<TDocument>(
+			appendPredicates(someTagsPredicate(tags))(params),
 		);
 	}
 

--- a/test/client-getAllBySomeTags.test.ts
+++ b/test/client-getAllBySomeTags.test.ts
@@ -28,7 +28,7 @@ test("returns all documents by tag from paginated response", async (t) => {
 		createMockRepositoryHandler(t, repositoryResponse),
 		createMockQueryHandler(t, pagedResponses, undefined, {
 			ref: getMasterRef(repositoryResponse),
-			q: `[[at(document.tags, [${documentTags
+			q: `[[any(document.tags, [${documentTags
 				.map((tag) => `"${tag}"`)
 				.join(", ")}])]]`,
 			pageSize: 100,
@@ -36,7 +36,7 @@ test("returns all documents by tag from paginated response", async (t) => {
 	);
 
 	const client = createTestClient(t);
-	const res = await client.getAllByTags(documentTags);
+	const res = await client.getAllBySomeTags(documentTags);
 
 	t.deepEqual(res, allDocs);
 	t.is(res.length, 3 * 3);
@@ -60,7 +60,7 @@ test("includes params if provided", async (t) => {
 		createMockRepositoryHandler(t),
 		createMockQueryHandler(t, pagedResponses, params.accessToken, {
 			ref: params.ref as string,
-			q: `[[at(document.tags, [${documentTags
+			q: `[[any(document.tags, [${documentTags
 				.map((tag) => `"${tag}"`)
 				.join(", ")}])]]`,
 			pageSize: 100,
@@ -69,7 +69,7 @@ test("includes params if provided", async (t) => {
 	);
 
 	const client = createTestClient(t);
-	const res = await client.getAllByTags(documentTags, params);
+	const res = await client.getAllBySomeTags(documentTags, params);
 
 	t.deepEqual(res, allDocs);
 	t.is(res.length, 3 * 3);

--- a/test/client-getByEveryTag.test.ts
+++ b/test/client-getByEveryTag.test.ts
@@ -1,0 +1,70 @@
+import test from "ava";
+import * as mswNode from "msw/node";
+
+import { createDocument } from "./__testutils__/createDocument";
+import { createMockQueryHandler } from "./__testutils__/createMockQueryHandler";
+import { createMockRepositoryHandler } from "./__testutils__/createMockRepositoryHandler";
+import { createQueryResponse } from "./__testutils__/createQueryResponse";
+import { createRepositoryResponse } from "./__testutils__/createRepositoryResponse";
+import { createTestClient } from "./__testutils__/createClient";
+import { getMasterRef } from "./__testutils__/getMasterRef";
+
+import * as prismic from "../src";
+
+const server = mswNode.setupServer();
+test.before(() => server.listen({ onUnhandledRequest: "error" }));
+test.after(() => server.close());
+
+test("queries for documents by tag", async (t) => {
+	const repositoryResponse = createRepositoryResponse();
+	const documentTags = ["foo", "bar"];
+	const queryResponse = createQueryResponse([
+		createDocument({ tags: documentTags }),
+		createDocument({ tags: documentTags }),
+	]);
+
+	server.use(
+		createMockRepositoryHandler(t, repositoryResponse),
+		createMockQueryHandler(t, [queryResponse], undefined, {
+			ref: getMasterRef(repositoryResponse),
+			q: `[[at(document.tags, [${documentTags
+				.map((tag) => `"${tag}"`)
+				.join(", ")}])]]`,
+		}),
+	);
+
+	const client = createTestClient(t);
+	const res = await client.getByEveryTag(documentTags);
+
+	t.deepEqual(res, queryResponse);
+});
+
+test("includes params if provided", async (t) => {
+	const params: prismic.BuildQueryURLArgs = {
+		accessToken: "custom-accessToken",
+		ref: "custom-ref",
+		lang: "*",
+	};
+
+	const documentTags = ["foo", "bar"];
+	const queryResponse = createQueryResponse([
+		createDocument({ tags: documentTags }),
+		createDocument({ tags: documentTags }),
+	]);
+
+	server.use(
+		createMockRepositoryHandler(t),
+		createMockQueryHandler(t, [queryResponse], params.accessToken, {
+			ref: params.ref as string,
+			q: `[[at(document.tags, [${documentTags
+				.map((tag) => `"${tag}"`)
+				.join(", ")}])]]`,
+			lang: params.lang,
+		}),
+	);
+
+	const client = createTestClient(t);
+	const res = await client.getByEveryTag(documentTags, params);
+
+	t.deepEqual(res, queryResponse);
+});

--- a/test/client-getBySomeTags.test.ts
+++ b/test/client-getBySomeTags.test.ts
@@ -1,0 +1,70 @@
+import test from "ava";
+import * as mswNode from "msw/node";
+
+import { createDocument } from "./__testutils__/createDocument";
+import { createMockQueryHandler } from "./__testutils__/createMockQueryHandler";
+import { createMockRepositoryHandler } from "./__testutils__/createMockRepositoryHandler";
+import { createQueryResponse } from "./__testutils__/createQueryResponse";
+import { createRepositoryResponse } from "./__testutils__/createRepositoryResponse";
+import { createTestClient } from "./__testutils__/createClient";
+import { getMasterRef } from "./__testutils__/getMasterRef";
+
+import * as prismic from "../src";
+
+const server = mswNode.setupServer();
+test.before(() => server.listen({ onUnhandledRequest: "error" }));
+test.after(() => server.close());
+
+test("queries for documents by tag", async (t) => {
+	const repositoryResponse = createRepositoryResponse();
+	const documentTags = ["foo", "bar"];
+	const queryResponse = createQueryResponse([
+		createDocument({ tags: documentTags }),
+		createDocument({ tags: documentTags }),
+	]);
+
+	server.use(
+		createMockRepositoryHandler(t, repositoryResponse),
+		createMockQueryHandler(t, [queryResponse], undefined, {
+			ref: getMasterRef(repositoryResponse),
+			q: `[[any(document.tags, [${documentTags
+				.map((tag) => `"${tag}"`)
+				.join(", ")}])]]`,
+		}),
+	);
+
+	const client = createTestClient(t);
+	const res = await client.getBySomeTags(documentTags);
+
+	t.deepEqual(res, queryResponse);
+});
+
+test("includes params if provided", async (t) => {
+	const params: prismic.BuildQueryURLArgs = {
+		accessToken: "custom-accessToken",
+		ref: "custom-ref",
+		lang: "*",
+	};
+
+	const documentTags = ["foo", "bar"];
+	const queryResponse = createQueryResponse([
+		createDocument({ tags: documentTags }),
+		createDocument({ tags: documentTags }),
+	]);
+
+	server.use(
+		createMockRepositoryHandler(t),
+		createMockQueryHandler(t, [queryResponse], params.accessToken, {
+			ref: params.ref as string,
+			q: `[[any(document.tags, [${documentTags
+				.map((tag) => `"${tag}"`)
+				.join(", ")}])]]`,
+			lang: params.lang,
+		}),
+	);
+
+	const client = createTestClient(t);
+	const res = await client.getBySomeTags(documentTags, params);
+
+	t.deepEqual(res, queryResponse);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Description

- Adds `getBySomeTags` and `getAllBySomeTags`. They query for documents with at least one of the given tags.
- Renames `getByTags` and `getAllByTags` to `getByEveryTag` and `getAllByEveryTag`. They query for documents with all of the given tags.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
![Aston Martin](https://images.unsplash.com/photo-1490559328922-7bf6c9d4efa0?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=500&q=80)

