### PR TITLE
fix: use MAX_PAGE_SIZE when pageSize param is nullish on getAll methods

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -573,7 +573,10 @@ export class Client {
 		params: Partial<Omit<BuildQueryURLArgs, "page">> & GetAllParams = {},
 	): Promise<TDocument[]> {
 		const { limit = Infinity, ...actualParams } = params;
-		const resolvedParams = { pageSize: MAX_PAGE_SIZE, ...actualParams };
+		const resolvedParams = {
+			...actualParams,
+			pageSize: actualParams.pageSize || MAX_PAGE_SIZE,
+		};
 
 		const result = await this.get<TDocument>(resolvedParams);
 

--- a/test/client-getAll.test.ts
+++ b/test/client-getAll.test.ts
@@ -53,8 +53,8 @@ test("includes params if provided", async (t) => {
 		createMockRepositoryHandler(t),
 		createMockQueryHandler(t, pagedResponses, params.accessToken, {
 			ref: params.ref as string,
-			pageSize: 100,
 			lang: params.lang,
+			pageSize: 100,
 		}),
 	);
 

--- a/test/client-getAllByEveryTag.test.ts
+++ b/test/client-getAllByEveryTag.test.ts
@@ -63,8 +63,8 @@ test("includes params if provided", async (t) => {
 			q: `[[at(document.tags, [${documentTags
 				.map((tag) => `"${tag}"`)
 				.join(", ")}])]]`,
-			pageSize: 100,
 			lang: params.lang,
+			pageSize: 100,
 		}),
 	);
 

--- a/test/client-getAllByIDs.test.ts
+++ b/test/client-getAllByIDs.test.ts
@@ -62,8 +62,8 @@ test("includes params if provided", async (t) => {
 			q: `[[in(document.id, [${allDocumentIds
 				.map((id) => `"${id}"`)
 				.join(", ")}])]]`,
-			pageSize: 100,
 			lang: params.lang,
+			pageSize: 100,
 		}),
 	);
 

--- a/test/client-getAllBySomeTags.test.ts
+++ b/test/client-getAllBySomeTags.test.ts
@@ -63,8 +63,8 @@ test("includes params if provided", async (t) => {
 			q: `[[any(document.tags, [${documentTags
 				.map((tag) => `"${tag}"`)
 				.join(", ")}])]]`,
-			pageSize: 100,
 			lang: params.lang,
+			pageSize: 100,
 		}),
 	);
 

--- a/test/client-getAllByTag.test.ts
+++ b/test/client-getAllByTag.test.ts
@@ -59,8 +59,8 @@ test("includes params if provided", async (t) => {
 		createMockQueryHandler(t, pagedResponses, params.accessToken, {
 			ref: params.ref as string,
 			q: `[[at(document.tags, "${documentTag}")]]`,
-			pageSize: 100,
 			lang: params.lang,
+			pageSize: 100,
 		}),
 	);
 

--- a/test/client-getAllByType.test.ts
+++ b/test/client-getAllByType.test.ts
@@ -59,8 +59,8 @@ test("includes params if provided", async (t) => {
 		createMockQueryHandler(t, pagedResponses, params.accessToken, {
 			ref: params.ref as string,
 			q: `[[at(document.type, "${documentType}")]]`,
-			pageSize: 100,
 			lang: params.lang,
+			pageSize: 100,
 		}),
 	);
 

--- a/test/client-getAllByUIDs.test.ts
+++ b/test/client-getAllByUIDs.test.ts
@@ -72,8 +72,8 @@ test("includes params if provided", async (t) => {
 					.map((uid) => `"${uid}"`)
 					.join(", ")}])]]`,
 			],
-			pageSize: 100,
 			lang: params.lang,
+			pageSize: 100,
 		}),
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

All `getAll*` methods default `pageSize` to `MAX_PAGE_SIZE` (currently 100). The default was only set if a `pageSize` parameter was not provided. For example, if a user provides a `pageSize` of `undefined`, `pageSize` will be `undefined`, not the default.

With this PR, `pageSize` will be set to `MAX_PAGE_SIZE` on any falsey value (including `0`, `undefined`, `null`, and no value).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🦧
