### PR TITLE
feat: ensure Prismic Rest API V2 endpoint is used

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -310,6 +310,17 @@ export class Client {
 	 * @returns A client that can query content from the repository.
 	 */
 	constructor(endpoint: string, options: ClientConfig = {}) {
+		if (
+			process.env.NODE_ENV === "development" &&
+			/\.prismic\.io\/(?!api\/v2\/?)/.test(endpoint)
+		) {
+			throw new PrismicError(
+				"@prismicio/client only supports Prismic Rest API V2. Please use the getEndpoint helper to generate a valid Rest API V2 endpoint URL.",
+				undefined,
+				undefined,
+			);
+		}
+
 		this.endpoint = endpoint;
 		this.accessToken = options.accessToken;
 		this.routes = options.routes;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -468,14 +468,16 @@ test.serial("throws PrismicError if response is not JSON", async (t) => {
 test.serial(
 	"throws if a prismic.io endpoint is given that is not for Rest API V2",
 	(t) => {
-		const message = /only supports Prismic Rest API V2/;
 		const fetch = sinon.stub();
 
 		t.throws(
 			() => {
 				prismic.createClient("https://qwerty.cdn.prismic.io/api/v1", { fetch });
 			},
-			{ message, instanceOf: prismic.PrismicError },
+			{
+				message: /only supports Prismic Rest API V2/,
+				instanceOf: prismic.PrismicError,
+			},
 		);
 
 		t.notThrows(() => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -464,3 +464,30 @@ test.serial("throws PrismicError if response is not JSON", async (t) => {
 		message: /invalid api response/i,
 	});
 });
+
+test.serial(
+	"throws if a prismic.io endpoint is given that is not for Rest API V2",
+	(t) => {
+		const message = /only supports Prismic Rest API V2/;
+		const fetch = sinon.stub();
+
+		t.throws(
+			() => {
+				prismic.createClient("https://qwerty.cdn.prismic.io/api/v1", { fetch });
+			},
+			{ message, instanceOf: prismic.PrismicError },
+		);
+
+		t.notThrows(() => {
+			prismic.createClient("https://example.com/custom/endpoint", { fetch });
+		}, "Non-prismic.io endpoints are not checked");
+
+		t.notThrows(() => {
+			prismic.createClient("https://qwerty.cdn.prismic.io/api/v2", { fetch });
+		}, "A valid prismic.io V2 endpoint does not throw");
+
+		t.notThrows(() => {
+			prismic.createClient(prismic.getEndpoint("qwerty"), { fetch });
+		}, "An endpoint created with getEndpoint does not throw");
+	},
+);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a check to ensure a Prismic Rest API V2 endpoint is provided.

It throws an error on client creation if the following criteria is met:

1. A `prismic.io` domain is used.
2. The endpoint does not contain `/api/v2`.
3. `process.env.NODE_ENV` is `development`.

If a custom domain is used (such as through a proxy), no check is performed since we cannot easily see which API version it implements.

Related issue: #200

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
<img src="https://images.unsplash.com/photo-1497752531616-c3afd9760a11?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=400&q=90" width="200" />
