### PR TITLE
chore(types): allow gerenic on `Document.data` #204

### DIFF
--- a/src/ApiSearchResponse.ts
+++ b/src/ApiSearchResponse.ts
@@ -1,6 +1,6 @@
 import { Document } from "./documents";
 
-export default interface ApiSearchResponse {
+export default interface ApiSearchResponse<T = any> {
   page: number;
   results_per_page: number;
   results_size: number;
@@ -8,5 +8,5 @@ export default interface ApiSearchResponse {
   total_pages: number;
   next_page: string;
   prev_page: string;
-  results: Document[];
+  results: Document<T>[];
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,13 +7,13 @@ import Api, { ApiOptions } from './Api';
 import { PreviewResolver, createPreviewResolver } from './PreviewResolver';
 
 export interface Client {
-  query(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
-  queryFirst(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document>;
-  getByID(id: string, options: QueryOptions, cb: RequestCallback<Document>): Promise<Document>;
-  getByIDs(ids: string[], options: QueryOptions, cb: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse>;
-  getByUID(type: string, uid: string, options: QueryOptions, cb: RequestCallback<Document>): Promise<Document>;
-  getSingle(type: string, options: QueryOptions, cb: RequestCallback<Document>): Promise<Document>;
-  getBookmark(bookmark: string, options: QueryOptions, cb: RequestCallback<Document>): Promise<Document>;
+  query<T>(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse<T>>, cb?: RequestCallback<ApiSearchResponse<T>>): Promise<ApiSearchResponse<T>>;
+  queryFirst<T>(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document<T>>, cb?: RequestCallback<Document<T>>): Promise<Document<T>>;
+  getByID<T>(id: string, options: QueryOptions, cb: RequestCallback<Document<T>>): Promise<Document<T>>;
+  getByIDs<T>(ids: string[], options: QueryOptions, cb: RequestCallback<ApiSearchResponse<T>>): Promise<ApiSearchResponse<T>>;
+  getByUID<T>(type: string, uid: string, options: QueryOptions, cb: RequestCallback<Document<T>>): Promise<Document<T>>;
+  getSingle<T>(type: string, options: QueryOptions, cb: RequestCallback<Document<T>>): Promise<Document<T>>;
+  getBookmark<T>(bookmark: string, options: QueryOptions, cb: RequestCallback<Document<T>>): Promise<Document<T>>;
   getPreviewResolver(token: string, documentId?: string): PreviewResolver;
 }
 
@@ -37,31 +37,31 @@ export class DefaultClient implements Client {
     return new LazySearchForm(formId, this.api);
   }
 
-  query(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse>, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse> {
+  query<T>(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<ApiSearchResponse<T>>, cb?: RequestCallback<ApiSearchResponse<T>>): Promise<ApiSearchResponse<T>> {
     return this.getApi().then(api => api.query(q, optionsOrCallback, cb));
   }
 
-  queryFirst(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document>, cb?: RequestCallback<Document>): Promise<Document> {
+  queryFirst<T>(q: string | string[], optionsOrCallback?: QueryOptions | RequestCallback<Document<T>>, cb?: RequestCallback<Document<T>>): Promise<Document<T>> {
     return this.getApi().then(api => api.queryFirst(q, optionsOrCallback, cb));
   }
 
-  getByID(id: string, options: QueryOptions, cb?: RequestCallback<Document>): Promise<Document> {
+  getByID<T>(id: string, options: QueryOptions, cb?: RequestCallback<Document<T>>): Promise<Document<T>> {
     return this.getApi().then(api => api.getByID(id, options, cb));
   }
 
-  getByIDs(ids: string[], options: QueryOptions, cb?: RequestCallback<ApiSearchResponse>): Promise<ApiSearchResponse> {
+  getByIDs<T>(ids: string[], options: QueryOptions, cb?: RequestCallback<ApiSearchResponse<T>>): Promise<ApiSearchResponse<T>> {
     return this.getApi().then(api => api.getByIDs(ids, options, cb));
   }
 
-  getByUID(type: string, uid: string, options: QueryOptions, cb?: RequestCallback<Document>): Promise<Document> {
+  getByUID<T>(type: string, uid: string, options: QueryOptions, cb?: RequestCallback<Document<T>>): Promise<Document<T>> {
     return this.getApi().then(api => api.getByUID(type, uid, options, cb));
   }
 
-  getSingle(type: string, options: QueryOptions, cb?: RequestCallback<Document>): Promise<Document> {
+  getSingle<T>(type: string, options: QueryOptions, cb?: RequestCallback<Document<T>>): Promise<Document<T>> {
     return this.getApi().then(api => api.getSingle(type, options, cb));
   }
 
-  getBookmark(bookmark: string, options: QueryOptions, cb?: RequestCallback<Document>): Promise<Document> {
+  getBookmark<T>(bookmark: string, options: QueryOptions, cb?: RequestCallback<Document<T>>): Promise<Document<T>> {
     return this.getApi().then(api => api.getBookmark(bookmark, options, cb));
   }
 

--- a/src/documents.ts
+++ b/src/documents.ts
@@ -5,7 +5,7 @@ export interface AlternateLanguage {
   lang: string;
 }
 
-export interface Document {
+export interface Document<T = any> {
   id: string;
   uid?: string;
   url?: string;
@@ -17,5 +17,5 @@ export interface Document {
   alternate_languages: AlternateLanguage[];
   first_publication_date: string | null;
   last_publication_date: string | null;
-  data: any;
+  data: T;
 }


### PR DESCRIPTION
I added the possibility to type the data inside Document, if not added, default still any.

```ts
type Post = {
  title: RichTextBlock[];
  content: RichTextBlock[];
}

const response = await prismic.query<Post>(
    [Prismic.predicates.at("document.type", "post")],
    {
      pageSize: PAGE_SIZE,
      graphQuery: `{
         post {
           title
           content
          }
        }`,
    }
  );
```

<img width="528" alt="image" src="https://user-images.githubusercontent.com/2790845/146450236-b6b32fe6-4b52-4e97-b945-ba394ae1f2bb.png">
