### PR TITLE
fix: resolve previewed document URL any language

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1167,6 +1167,7 @@ export class Client {
 		if (documentID != null) {
 			const document = await this.getByID(documentID, {
 				ref: previewToken,
+				lang: "*",
 			});
 
 			// We know we have a valid field to resolve since we are using prismicH.documentToLinkField

--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -31,6 +31,7 @@ test.serial("resolves a preview url in the browser", async (t) => {
 		createMockQueryHandler(t, [queryResponse], undefined, {
 			ref: previewToken,
 			q: `[[at(document.id, "${documentId}")]]`,
+			lang: "*",
 		}),
 	);
 
@@ -59,6 +60,7 @@ test.serial("resolves a preview url using a server req object", async (t) => {
 		createMockQueryHandler(t, [queryResponse], undefined, {
 			ref: previewToken,
 			q: `[[at(document.id, "${documentId}")]]`,
+			lang: "*",
 		}),
 	);
 
@@ -92,6 +94,7 @@ test.serial(
 			createMockQueryHandler(t, [queryResponse], undefined, {
 				ref: previewToken,
 				q: `[[at(document.id, "${documentID}")]]`,
+				lang: "*",
 			}),
 		);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Preview only works for the default language, fetch the preview document for all languages. Otherweise getByID will crash before calling the linkResolver

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
