### PR TITLE
chore: support React Native's Metro bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,6 @@
 	},
 	"publishConfig": {
 		"access": "public"
-	}
+	},
+	"react-native": "dist/index.js"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for use in React Native projects by adding an explicit `react-native` key to `package.json`. It points to the ES Module bundle.

### Background info

React Native's bundler (Metro) does not support `.cjs` files. Since Metro uses the `main` entry in `package.json`, it tries to load `dist/index.cjs` unsuccessfully.

Metro resolves package entry files using the following order:
- `react-native`
- `browser`
- `main`

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
⚛️
