### PR TITLE
docs: fix caching example by using `.clone()` method

### DIFF
--- a/examples/custom-caching/index.js
+++ b/examples/custom-caching/index.js
@@ -14,14 +14,14 @@ const client = prismic.createClient(endpoint, {
 
 		if (cache.has(key)) {
 			// If the cache contains a value for the key, return it
-			return cache.get(key);
+			return cache.get(key).clone();
 		} else {
 			// Otherwise, make the network request
 			const res = await fetch(url, options);
 
 			if (res.ok) {
 				// If the request was successful, save it to the cache
-				cache.set(key, res);
+				cache.set(key, res.clone());
 			}
 
 			return res;

--- a/examples/with-express/index.js
+++ b/examples/with-express/index.js
@@ -16,14 +16,14 @@ const client = prismic.createClient(endpoint, {
 
 		if (cache.has(key)) {
 			// If the cache contains a value for the key, return it
-			return cache.get(key);
+			return cache.get(key).clone();
 		} else {
 			// Otherwise, make the network request
 			const res = await fetch(url, options);
 
 			if (res.ok) {
 				// If the request was successful, save it to the cache
-				cache.set(key, res);
+				cache.set(key, res.clone());
 			}
 
 			return res;


### PR DESCRIPTION
The `.json()` cannot be resolved more than once for the same request

<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Fix caching example mentioned https://github.com/prismicio/prismic-client/issues/217

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
