### PR TITLE
fix: minify GraphQL queries by removing whitespace

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1268,7 +1268,8 @@ export class Client {
 	/**
 	 * A `fetch()` function to be used with GraphQL clients configured for
 	 * Prismic's GraphQL API. It automatically applies the necessary `prismic-ref`
-	 * and Authorization headers.
+	 * and Authorization headers. Queries will automatically be minified by
+	 * removing whitespace where possible.
 	 *
 	 * @example
 	 *

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import { findMasterRef } from "./lib/findMasterRef";
 import { findRefByID } from "./lib/findRefByID";
 import { findRefByLabel } from "./lib/findRefByLabel";
 import { getCookie } from "./lib/getCookie";
+import { minifyGraphQLQuery } from "./lib/minifyGraphQLQuery";
 
 import { FetchLike, HttpRequestLike } from "./types";
 import { buildQueryURL, BuildQueryURLArgs } from "./buildQueryURL";
@@ -16,7 +17,6 @@ import { PrismicError } from "./PrismicError";
 import { predicate } from "./predicate";
 import * as cookie from "./cookie";
 import { NotFoundError } from "./NotFoundError";
-import { removeGraphQLQueryWhitespace } from "./lib/removeGraphQLQueryWhitespace";
 
 /**
  * The largest page size allowed by the Prismic REST API V2. This value is used
@@ -1332,7 +1332,7 @@ export class Client {
 		);
 		const query = url.searchParams.get("query");
 		if (query) {
-			url.searchParams.set("query", removeGraphQLQueryWhitespace(query));
+			url.searchParams.set("query", minifyGraphQLQuery(query));
 		}
 
 		return (await this.fetchFn(url.toString(), {

--- a/src/lib/minifyGraphQLQuery.ts
+++ b/src/lib/minifyGraphQLQuery.ts
@@ -1,0 +1,13 @@
+/**
+ * Minifies a GraphQL query by removing whitespace where possible.
+ *
+ * @param query - GraphQL query to minify.
+ *
+ * @returns A minified version of `query`.
+ */
+export const minifyGraphQLQuery = (query: string): string => {
+	return query.replace(
+		/(\n| )*( |{|})(\n| )*/gm,
+		(_chars, _spaces, brackets) => brackets,
+	);
+};

--- a/src/lib/removeGraphQLQueryWhitespace.ts
+++ b/src/lib/removeGraphQLQueryWhitespace.ts
@@ -1,0 +1,6 @@
+export const removeGraphQLQueryWhitespace = (query: string): string => {
+	return query.replace(
+		/(\n| )*( |{|})(\n| )*/gm,
+		(_chars, _spaces, brackets) => brackets,
+	);
+};

--- a/src/lib/removeGraphQLQueryWhitespace.ts
+++ b/src/lib/removeGraphQLQueryWhitespace.ts
@@ -1,6 +1,0 @@
-export const removeGraphQLQueryWhitespace = (query: string): string => {
-	return query.replace(
-		/(\n| )*( |{|})(\n| )*/gm,
-		(_chars, _spaces, brackets) => brackets,
-	);
-};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

GraphQL queries resolved by `graphqlFetch()` should be minified by removing whitespace wherever possible. This PR adds this functionality.

Note that `graphqlFetch()` is still considered experimental. Its functionality and API may change.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐻
