### PR TITLE
fix: resolve `'document.tags' expected a [list] of 'string' literals` error when using tag methods with a single tag

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,7 @@ import * as prismicT from "@prismicio/types";
 import * as prismicH from "@prismicio/helpers";
 
 import { appendPredicates } from "./lib/appendPredicates";
+import { castArray } from "./lib/castArray";
 import { castThunk } from "./lib/castThunk";
 import { findMasterRef } from "./lib/findMasterRef";
 import { findRefByID } from "./lib/findRefByID";
@@ -205,7 +206,7 @@ const typePredicate = (documentType: string): string =>
  * @returns A predicate that can be used in a Prismic REST API V2 request.
  */
 const everyTagPredicate = (tags: string | string[]): string =>
-	predicate.at("document.tags", tags);
+	predicate.at("document.tags", castArray(tags));
 
 /**
  * Creates a predicate to filter content by document tags. At least one matching
@@ -216,7 +217,7 @@ const everyTagPredicate = (tags: string | string[]): string =>
  * @returns A predicate that can be used in a Prismic REST API V2 request.
  */
 const someTagsPredicate = (tags: string | string[]): string =>
-	predicate.any("document.tags", tags);
+	predicate.any("document.tags", castArray(tags));
 
 /**
  * Creates a Prismic client that can be used to query a repository.
@@ -842,7 +843,7 @@ export class Client {
 		params?: Partial<BuildQueryURLArgs>,
 	): Promise<prismicT.Query<TDocument>> {
 		return await this.get<TDocument>(
-			appendPredicates(params, everyTagPredicate(tag)),
+			appendPredicates(params, someTagsPredicate(tag)),
 		);
 	}
 
@@ -868,7 +869,7 @@ export class Client {
 		params?: Partial<Omit<BuildQueryURLArgs, "page">>,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
-			appendPredicates(params, everyTagPredicate(tag)),
+			appendPredicates(params, someTagsPredicate(tag)),
 		);
 	}
 

--- a/test/client-getAllByTag.test.ts
+++ b/test/client-getAllByTag.test.ts
@@ -28,7 +28,7 @@ test("returns all documents by tag from paginated response", async (t) => {
 		createMockRepositoryHandler(t, repositoryResponse),
 		createMockQueryHandler(t, pagedResponses, undefined, {
 			ref: getMasterRef(repositoryResponse),
-			q: `[[at(document.tags, "${documentTag}")]]`,
+			q: `[[any(document.tags, ["${documentTag}"])]]`,
 			pageSize: 100,
 		}),
 	);
@@ -58,7 +58,7 @@ test("includes params if provided", async (t) => {
 		createMockRepositoryHandler(t),
 		createMockQueryHandler(t, pagedResponses, params.accessToken, {
 			ref: params.ref as string,
-			q: `[[at(document.tags, "${documentTag}")]]`,
+			q: `[[any(document.tags, ["${documentTag}"])]]`,
 			lang: params.lang,
 			pageSize: 100,
 		}),

--- a/test/client-getByTag.test.ts
+++ b/test/client-getByTag.test.ts
@@ -27,7 +27,7 @@ test("queries for documents by tag", async (t) => {
 		createMockRepositoryHandler(t, repositoryResponse),
 		createMockQueryHandler(t, [queryResponse], undefined, {
 			ref: getMasterRef(repositoryResponse),
-			q: `[[at(document.tags, "${documentTag}")]]`,
+			q: `[[any(document.tags, ["${documentTag}"])]]`,
 		}),
 	);
 
@@ -54,7 +54,7 @@ test("includes params if provided", async (t) => {
 		createMockRepositoryHandler(t),
 		createMockQueryHandler(t, [queryResponse], params.accessToken, {
 			ref: params.ref as string,
-			q: `[[at(document.tags, "${documentTag}")]]`,
+			q: `[[any(document.tags, ["${documentTag}"])]]`,
 			lang: params.lang,
 		}),
 	);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR resolves the following API error when error when using tag methods with a single tag.

```
'document.tags' expected a [list] of 'string' literals... [truncated]
```

This error is returned by the API when using a tag method like the following:

```ts
// API error
client.getAllByTag('tag')
```

After this PR, this now works:

```ts
// Works
client.getAllByTag('tag')
```

This is resolved by ensuring tag methods always use an array predicate parameter, even for single tag queries.

**Note**: This PR also changes `getByTag()` and `getAllByTag()` to use the `any` predicate rather than `at`. This allows matches against documents that have multiple tags.

Fixes: #215

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐱
