### PR TITLE
feat: support providing a repository name to `createClient()` in place of an API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ The official JavaScript + TypeScript client library for [Prismic][prismic].
 import * as prismic from "@prismicio/client";
 
 // Create a client
-const endpoint = prismic.getRepositoryEndpoint("my-repository");
-const client = prismic.createClient(endpoint);
+const client = prismic.createClient("my-repository");
 
 // Then query for your content
 const blogPosts = await client.getAllByType("blog_post");

--- a/examples/custom-caching/index.js
+++ b/examples/custom-caching/index.js
@@ -2,12 +2,11 @@ import * as prismic from "@prismicio/client";
 import fetch from "node-fetch";
 import QuickLRU from "quick-lru";
 
-const endpoint = prismic.getRepositoryEndpoint("qwerty");
 const cache = new QuickLRU({
 	maxSize: 1000, // 1000 entries
 });
 
-const client = prismic.createClient(endpoint, {
+const client = prismic.createClient("qwerty", {
 	fetch: async (url, options) => {
 		// The cache key contains the requested URL and headers
 		const key = JSON.stringify({ url, options });

--- a/examples/custom-timeout/index.js
+++ b/examples/custom-timeout/index.js
@@ -5,11 +5,9 @@ import fetch, { AbortError } from "node-fetch";
 // version >=14.17.0, or are not in a node environment, remove this line.
 import { AbortController } from "abort-controller";
 
-const endpoint = prismic.getRepositoryEndpoint("qwerty");
-
 // A global timeout can be implemented like the following. This timeout will
 // apply to all network requests made by the client.
-const client = prismic.createClient(endpoint, {
+const client = prismic.createClient("qwerty", {
 	fetch: async (url, options) => {
 		// Create an AbortController. This will be used to cancel the
 		// `fetch()` request if it does not resolve within the given

--- a/examples/multiple-languages/index.js
+++ b/examples/multiple-languages/index.js
@@ -1,8 +1,7 @@
 import * as prismic from "@prismicio/client";
 import fetch from "node-fetch";
 
-const endpoint = prismic.getRepositoryEndpoint("qwerty");
-const client = prismic.createClient(endpoint, {
+const client = prismic.createClient("qwerty", {
 	fetch,
 	// A default language can be set here. If a `lang` option is not set, your
 	// repository's default language will be used.

--- a/examples/releases/index.js
+++ b/examples/releases/index.js
@@ -1,8 +1,7 @@
 import * as prismic from "@prismicio/client";
 import fetch from "node-fetch";
 
-const endpoint = prismic.getRepositoryEndpoint("qwerty");
-const client = prismic.createClient(endpoint, {
+const client = prismic.createClient("qwerty", {
 	fetch,
 });
 

--- a/examples/server-usage/index.js
+++ b/examples/server-usage/index.js
@@ -1,8 +1,7 @@
 import * as prismic from "@prismicio/client";
 import fetch from "node-fetch";
 
-const endpoint = prismic.getRepositoryEndpoint("qwerty");
-const client = prismic.createClient(endpoint, {
+const client = prismic.createClient("qwerty", {
 	// Here, we provide a way for the client to make network requests.
 	// `node-fetch` is a Node.js fetch-compatible package.
 	fetch,

--- a/examples/using-refs/index.js
+++ b/examples/using-refs/index.js
@@ -1,8 +1,7 @@
 import * as prismic from "@prismicio/client";
 import fetch from "node-fetch";
 
-const endpoint = prismic.getRepositoryEndpoint("qwerty");
-const client = prismic.createClient(endpoint, {
+const client = prismic.createClient("qwerty", {
 	fetch,
 });
 

--- a/examples/with-express/index.js
+++ b/examples/with-express/index.js
@@ -4,12 +4,11 @@ import fetch from "node-fetch";
 import express from "express";
 import QuickLRU from "quick-lru";
 
-const endpoint = prismic.getRepositoryEndpoint("qwerty");
 const cache = new QuickLRU({
 	maxSize: 1000, // 1000 entries
 });
 
-const client = prismic.createClient(endpoint, {
+const client = prismic.createClient("qwerty", {
 	fetch: async (url, options) => {
 		// The cache key contains the requested URL and headers
 		const key = JSON.stringify({ url, options });

--- a/examples/with-typescript/index.ts
+++ b/examples/with-typescript/index.ts
@@ -54,8 +54,7 @@ type PrismicDocumentBlogPost = prismicT.PrismicDocument<
 >;
 
 const main = async () => {
-	const endpoint = prismic.getRepositoryEndpoint("qwerty");
-	const client = prismic.createClient(endpoint, { fetch });
+	const client = prismic.createClient("qwerty", { fetch });
 
 	// We can pass a type to client methods that return documents.
 	// Here, we tell `client.getByUID` that the document type will be a `PrismicDocumentPage`.

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -21,12 +21,29 @@ test.before(() => server.listen({ onUnhandledRequest: "error" }));
 test.after(() => server.close());
 
 test.serial("createClient creates a Client", (t) => {
+	const client = prismic.createClient("qwerty", {
+		fetch: sinon.stub(),
+	});
+
+	t.true(client instanceof prismic.Client);
+});
+
+test.serial("creates a client with a repository name", (t) => {
+	const repositoryName = "qwerty";
+	const client = prismic.createClient(repositoryName, {
+		fetch: sinon.stub(),
+	});
+
+	t.is(client.endpoint, prismic.getRepositoryEndpoint(repositoryName));
+});
+
+test.serial("creates a client with a Rest API V2 endpoint", (t) => {
 	const endpoint = prismic.getRepositoryEndpoint("qwerty");
 	const client = prismic.createClient(endpoint, {
 		fetch: sinon.stub(),
 	});
 
-	t.true(client instanceof prismic.Client);
+	t.is(client.endpoint, endpoint);
 });
 
 test.serial("client has correct default state", (t) => {
@@ -46,6 +63,40 @@ test.serial("client has correct default state", (t) => {
 	t.is(client.fetchFn, options.fetch as prismic.FetchLike);
 	t.is(client.defaultParams, options.defaultParams);
 });
+
+test.serial(
+	"constructor throws if an invalid repository name is provided",
+	(t) => {
+		t.throws(
+			() => {
+				prismic.createClient("invalid repository name", {
+					fetch: sinon.stub(),
+				});
+			},
+			{
+				instanceOf: prismic.PrismicError,
+				message: /an invalid Prismic repository name was given/i,
+			},
+		);
+	},
+);
+
+test.serial(
+	"constructor throws if an invalid repository endpoint is provided",
+	(t) => {
+		t.throws(
+			() => {
+				prismic.createClient("https://invalid url.cdn.prismic.io/api/v2", {
+					fetch: sinon.stub(),
+				});
+			},
+			{
+				instanceOf: prismic.PrismicError,
+				message: /an invalid Prismic repository name was given/i,
+			},
+		);
+	},
+);
 
 test.serial("constructor throws if fetch is unavailable", (t) => {
 	const endpoint = prismic.getRepositoryEndpoint("qwerty");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for providing a repository name to `createClient()` in place of an API endpoint.

```ts
import { createClient } from "@prismicio/client";

const client = prismic.createClient("repo-name");
```

Passing an API endpoint is still supported:

```ts
import { createClient } from "@prismicio/client";

const endpoint = prismic.getRepositoryEndpoint("repo-name");
const client = prismic.createClient(endpoint);
```

If the first argument for `createClient()` is not an endpoint, it will build one using `getRepositoryEndpoint()` automatically.

This takes advantage of the `isRepositoryEndpoint()` helper introduced in #222.

Related: https://github.com/prismicio/prismic-helpers/issues/42

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🦄
