### PR TITLE
fix: return the default URL when `resolvePreviewURL()` does not resolve to a string URL

### DIFF
--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -167,6 +167,34 @@ test.serial(
 	},
 );
 
+test.serial("returns defaultURL if resolved URL is not a string", async (t) => {
+	const defaultURL = "defaultURL";
+	const document = createDocument();
+	const queryResponse = createQueryResponse([document]);
+
+	const documentID = document.id;
+	const previewToken = "previewToken";
+
+	server.use(
+		createMockRepositoryHandler(t),
+		createMockQueryHandler(t, [queryResponse], undefined, {
+			ref: previewToken,
+			q: `[[at(document.id, "${documentID}")]]`,
+			lang: "*",
+		}),
+	);
+
+	const client = createTestClient(t);
+	const res = await client.resolvePreviewURL({
+		linkResolver: () => null,
+		defaultURL,
+		documentID,
+		previewToken,
+	});
+
+	t.is(res, defaultURL);
+});
+
 test("is abortable with an AbortController", async (t) => {
 	const repositoryResponse = createRepositoryResponse();
 	const document = createDocument();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where `resolvePreviewURL()` could return `null` (or some non-string value) in certain cases. This can happen if the provided Link Resolver does not return a string for a particular document. Note that it is valid for a Link Resolver to return a non-string value or choose to not handle certain document types, but `resolvePreviewURL()` requires a string value since a URL is required.

With this PR, `resolvePreviewURL()` will return the given `defaultURL` argument if the resolved URL is not a string.

Fixes: #225

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🐛
