### PR TITLE
fix: add `limit` to all `getAll*()` methods (fixes #233)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -218,7 +218,7 @@ const typePredicate = (documentType: string): string =>
  * Creates a predicate to filter content by document tags. All tags are required
  * on the document.
  *
- * @param documentType - Document tags to filter queried content.
+ * @param tags - Document tags to filter queried content.
  *
  * @returns A predicate that can be used in a Prismic REST API V2 request.
  */
@@ -229,7 +229,7 @@ const everyTagPredicate = (tags: string | string[]): string =>
  * Creates a predicate to filter content by document tags. At least one matching
  * tag is required on the document.
  *
- * @param documentType - Document tags to filter queried content.
+ * @param tags - Document tags to filter queried content.
  *
  * @returns A predicate that can be used in a Prismic REST API V2 request.
  */
@@ -257,8 +257,9 @@ const someTagsPredicate = (tags: string | string[]): string =>
  * @returns A client that can query content from the repository.
  */
 export const createClient = (
-	...args: ConstructorParameters<typeof Client>
-): Client => new Client(...args);
+	repositoryNameOrEndpoint: ConstructorParameters<typeof Client>[0],
+	options: ConstructorParameters<typeof Client>[1] = {},
+): Client => new Client(repositoryNameOrEndpoint, options);
 
 /**
  * A client that allows querying content from a Prismic repository.
@@ -658,7 +659,7 @@ export class Client {
 	 */
 	async getAllByIDs<TDocument extends prismicT.PrismicDocument>(
 		ids: string[],
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendPredicates(params, predicate.in("document.id", ids)),
@@ -764,7 +765,7 @@ export class Client {
 	async getAllByUIDs<TDocument extends prismicT.PrismicDocument>(
 		documentType: string,
 		uids: string[],
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendPredicates(params, [
@@ -849,7 +850,9 @@ export class Client {
 	 */
 	async getAllByType<TDocument extends prismicT.PrismicDocument>(
 		documentType: string,
-		params?: Partial<Omit<BuildQueryURLArgs, "page">> & FetchParams,
+		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
+			GetAllParams &
+			FetchParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendPredicates(params, typePredicate(documentType)),
@@ -901,7 +904,9 @@ export class Client {
 	 */
 	async getAllByTag<TDocument extends prismicT.PrismicDocument>(
 		tag: string,
-		params?: Partial<Omit<BuildQueryURLArgs, "page">> & FetchParams,
+		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
+			GetAllParams &
+			FetchParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendPredicates(params, someTagsPredicate(tag)),
@@ -953,7 +958,9 @@ export class Client {
 	 */
 	async getAllByEveryTag<TDocument extends prismicT.PrismicDocument>(
 		tags: string[],
-		params?: Partial<Omit<BuildQueryURLArgs, "page">> & FetchParams,
+		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
+			GetAllParams &
+			FetchParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendPredicates(params, everyTagPredicate(tags)),
@@ -1005,7 +1012,9 @@ export class Client {
 	 */
 	async getAllBySomeTags<TDocument extends prismicT.PrismicDocument>(
 		tags: string[],
-		params?: Partial<Omit<BuildQueryURLArgs, "page">> & FetchParams,
+		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
+			GetAllParams &
+			FetchParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendPredicates(params, someTagsPredicate(tags)),
@@ -1258,7 +1267,7 @@ export class Client {
 	 * const document = await client.getByID("WW4bKScAAMAqmluX");
 	 * ```
 	 *
-	 * @param id - The ID of the Release.
+	 * @param releaseID - The ID of the Release.
 	 */
 	queryContentFromReleaseByID(releaseID: string): void {
 		this.refState = {
@@ -1281,7 +1290,7 @@ export class Client {
 	 * const document = await client.getByID("WW4bKScAAMAqmluX");
 	 * ```
 	 *
-	 * @param label - The label of the Release.
+	 * @param releaseLabel - The label of the Release.
 	 */
 	queryContentFromReleaseByLabel(releaseLabel: string): void {
 		this.refState = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds types for the `limit` parameter to all `getAll*()` methods.

Before this PR, only `dangerouslyGetAll()` was property typed to accept the `limit` param. All `getAll*()` methods accepted the `limit` param at runtime.

Fixes #233

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐔
