### PR TITLE
fix: throw when given a non-V2 Prismic Rest API in all non-production environments

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -342,7 +342,7 @@ export class Client {
 	constructor(repositoryNameOrEndpoint: string, options: ClientConfig = {}) {
 		if (isRepositoryEndpoint(repositoryNameOrEndpoint)) {
 			if (
-				process.env.NODE_ENV === "development" &&
+				process.env.NODE_ENV !== "production" &&
 				/\.prismic\.io\/(?!api\/v2\/?)/.test(repositoryNameOrEndpoint)
 			) {
 				throw new PrismicError(

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -98,6 +98,23 @@ test.serial(
 	},
 );
 
+test.serial(
+	"constructor throws if a non-V2 Prismic Rest API endpoint is provided",
+	(t) => {
+		t.throws(
+			() => {
+				prismic.createClient("https://qwerty.cdn.prismic.io/api/v1", {
+					fetch: sinon.stub(),
+				});
+			},
+			{
+				instanceOf: prismic.PrismicError,
+				message: /only supports prismic rest api v2/i,
+			},
+		);
+	},
+);
+
 test.serial("constructor throws if fetch is unavailable", (t) => {
 	const endpoint = prismic.getRepositoryEndpoint("qwerty");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR changes an existing check to ensure a Prismic Rest API V2 endpoint is used.

Before this PR, the client would throw an error on instantiation if it detected a non-V2 endpoint _only in development_. The check now happens in any environment other than production, including tests.

Detecting the production environment is done by evaluating `process.env.NODE_ENV !== "production"`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐤
