### PR TITLE
fix: optimize `pageSize` when a `limit` less than `pageSize` is given

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -547,8 +547,10 @@ export class Client {
 		const { limit = Infinity, ...actualParams } = params;
 		const resolvedParams = {
 			...actualParams,
-			pageSize:
+			pageSize: Math.min(
+				limit,
 				actualParams.pageSize || this.defaultParams?.pageSize || MAX_PAGE_SIZE,
+			),
 		};
 
 		const documents: TDocument[] = [];

--- a/test/client-dangerouslyGetAll.test.ts
+++ b/test/client-dangerouslyGetAll.test.ts
@@ -185,7 +185,7 @@ test("optimizes pageSize when limit is below the pageSize", async (t) => {
 	await client.dangerouslyGetAll({ limit: 3 });
 });
 
-test("does not optimize pageSize when limit above the pageSize", async (t) => {
+test("does not optimize pageSize when limit is above the pageSize", async (t) => {
 	const repositoryResponse = createRepositoryResponse();
 	const pagedResponses = createQueryResponsePages({
 		numPages: 1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR optimizes `pageSize` when a `limit` is given that is less than `pageSize`.

Before this PR, `pageSize` would always be the given value or the default (`100`). This means more documents may be fetched than needed to satisfy the `limit` param.

Closes: #232

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [ ] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
