### PR TITLE
feat: declare document TypeScript types in `createClient()`

### DIFF
--- a/examples/with-typescript/index.ts
+++ b/examples/with-typescript/index.ts
@@ -1,87 +1,38 @@
 import * as prismic from "@prismicio/client";
-import * as prismicT from "@prismicio/types";
 import fetch from "node-fetch";
 
-/**
- * A Page document from Prismic.
- */
-type PrismicDocumentPage = prismicT.PrismicDocument<
-	{
-		title: prismicT.KeyTextField;
-		footnotes: prismicT.RichTextField;
-	},
-	"page",
-	"en-us" | "fr-fr"
->;
-
-/**
- * A Blog Post document from Prismic. This example contains Slices.
- */
-type PrismicSliceBlogPostBodyText = prismicT.Slice<
-	"text",
-	never,
-	{
-		text: prismicT.RichTextField;
-	}
->;
-type PrismicSliceBlogPostBodyImageGallery = prismicT.Slice<
-	"image_gallery",
-	never,
-	{
-		image: prismicT.ImageField;
-		caption: prismicT.KeyTextField;
-	}
->;
-type PrismicSliceBlogPostBodyQuote = prismicT.Slice<
-	"quote",
-	{
-		quote: prismicT.RichTextField;
-		quotee: prismicT.KeyTextField;
-	}
->;
-type PrismicDocumentBlogPost = prismicT.PrismicDocument<
-	{
-		title: prismicT.KeyTextField;
-		description: prismicT.RichTextField;
-		body: prismicT.SliceZone<
-			| PrismicSliceBlogPostBodyText
-			| PrismicSliceBlogPostBodyImageGallery
-			| PrismicSliceBlogPostBodyQuote
-		>;
-	},
-	"page",
-	"en-us" | "fr-fr"
->;
+// See `./types.ts` for the document types.
+import { AllDocumentTypes } from "./types";
 
 const main = async () => {
-	const client = prismic.createClient("qwerty", { fetch });
+	// You can pass a union of document types to `createClient()`.
+	// All query methods will now be typed appropriately. Methods that
+	// accept a document type, for example, will return the correct type
+	// for that document type.
+	const client = prismic.createClient<AllDocumentTypes>("qwerty", { fetch });
 
-	// We can pass a type to client methods that return documents.
-	// Here, we tell `client.getByUID` that the document type will be a `PrismicDocumentPage`.
-	const homepage = await client.getByUID<PrismicDocumentPage>("page", "home");
-	// => The Page document with a UID of `home`
+	const homepage = await client.getByUID("page", "home");
+	//    ^ Typed as PageDocument
 
 	const type = homepage.type;
-	// => Typed as `"page"`
+	//                    ^ Typed as "page"
 	console.info("title: ", type);
 
 	const lang = homepage.lang;
-	// => Typed as `"en-us" | "fr-fr"`
+	//                    ^ Typed as `"en-us" | "fr-fr"`
 	console.info("lang: ", lang);
 
 	const title = homepage.data.title;
-	// => Typed as `string | null`
+	//                          ^ Typed as `string | null`
 	console.info("title: ", title);
 
 	// @ts-expect-error - non_existant_field does not exist in `data`
 	const nonExistantField = homepage.data.non_existant_field;
-	// TypeScript Error: Property 'non_existant_field' does not exist on type '{ title: KeyTextField; }'
+	// TypeScript Error: Property `non_existant_field` does not exist on type `PageDocument['data']`
 	console.info("nonExistantField: ", nonExistantField);
 
-	const blogPosts = await client.getAllByType<PrismicDocumentBlogPost>(
-		"blog_post",
-	);
-	// => All Blog Post documents.
+	const blogPosts = await client.getAllByType("blog_post");
+	//    ^ Typed as BlogPostDocument[]
 	console.info("blogPosts: ", blogPosts);
 };
 

--- a/examples/with-typescript/index.ts
+++ b/examples/with-typescript/index.ts
@@ -26,14 +26,18 @@ const main = async () => {
 	//                          ^ Typed as `string | null`
 	console.info("title: ", title);
 
-	// @ts-expect-error - non_existant_field does not exist in `data`
-	const nonExistantField = homepage.data.non_existant_field;
-	// TypeScript Error: Property `non_existant_field` does not exist on type `PageDocument['data']`
-	console.info("nonExistantField: ", nonExistantField);
+	// @ts-expect-error - non_existent_field does not exist in `data`
+	const nonExistentField = homepage.data.non_existent_field;
+	// TypeScript Error: Property 'non_existent_field' does not exist on type 'PageDocument['data']'.
+	console.info("nonExistentField: ", nonExistentField);
 
 	const blogPosts = await client.getAllByType("blog_post");
 	//    ^ Typed as BlogPostDocument[]
 	console.info("blogPosts: ", blogPosts);
+
+	// @ts-expect-error - "settings" is a not a valid document type.
+	await client.getAllByType("settings");
+	// TypeScript Error: Argument of type '"settings"' is not assignable to parameter of type '"page" | "blog_post"'.
 };
 
 main();

--- a/examples/with-typescript/types.ts
+++ b/examples/with-typescript/types.ts
@@ -1,0 +1,57 @@
+import * as prismicT from "@prismicio/types";
+
+/**
+ * A union of all possible Prismic Document types.
+ */
+export type AllDocumentTypes = PageDocument | BlogPostDocument;
+
+/**
+ * A Page document from Prismic.
+ */
+export type PageDocument = prismicT.PrismicDocument<
+	{
+		title: prismicT.KeyTextField;
+		footnotes: prismicT.RichTextField;
+	},
+	"page",
+	"en-us" | "fr-fr"
+>;
+
+/**
+ * A Blog Post document from Prismic. This example contains Slices.
+ */
+export type BlogPostDocument = prismicT.PrismicDocument<
+	{
+		title: prismicT.KeyTextField;
+		description: prismicT.RichTextField;
+		body: prismicT.SliceZone<
+			| PrismicSliceBlogPostBodyText
+			| PrismicSliceBlogPostBodyImageGallery
+			| PrismicSliceBlogPostBodyQuote
+		>;
+	},
+	"blog_post",
+	"en-us" | "fr-fr"
+>;
+type PrismicSliceBlogPostBodyText = prismicT.Slice<
+	"text",
+	never,
+	{
+		text: prismicT.RichTextField;
+	}
+>;
+type PrismicSliceBlogPostBodyImageGallery = prismicT.Slice<
+	"image_gallery",
+	never,
+	{
+		image: prismicT.ImageField;
+		caption: prismicT.KeyTextField;
+	}
+>;
+type PrismicSliceBlogPostBodyQuote = prismicT.Slice<
+	"quote",
+	{
+		quote: prismicT.RichTextField;
+		quotee: prismicT.KeyTextField;
+	}
+>;

--- a/src/client.ts
+++ b/src/client.ts
@@ -486,7 +486,7 @@ export class Client<
 	 *
 	 * @returns A paginated response containing the result of the query.
 	 */
-	async query<TDocument extends prismicT.PrismicDocument>(
+	async query<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		predicates: NonNullable<BuildQueryURLArgs["predicates"]>,
 		params?: Partial<Omit<BuildQueryURLArgs, "predicates">> & FetchParams,
 	): Promise<prismicT.Query<TDocument>> {
@@ -509,7 +509,7 @@ export class Client<
 	 *
 	 * @returns A paginated response containing the result of the query.
 	 */
-	async get<TDocument extends prismicT.PrismicDocument>(
+	async get<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<prismicT.Query<TDocument>> {
 		const url = await this.buildQueryURL(params);
@@ -531,7 +531,7 @@ export class Client<
 	 * @param params - Parameters to filter, sort, and paginate results. @returns
 	 *   The first result of the query, if any.
 	 */
-	async getFirst<TDocument extends prismicT.PrismicDocument>(
+	async getFirst<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<TDocument> {
 		const url = await this.buildQueryURL(params);
@@ -567,7 +567,9 @@ export class Client<
 	 *
 	 * @returns A list of documents matching the query.
 	 */
-	async dangerouslyGetAll<TDocument extends prismicT.PrismicDocument>(
+	async dangerouslyGetAll<
+		TDocument extends DocumentTypeMap[keyof DocumentTypeMap],
+	>(
 		params: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
 			FetchParams = {},
@@ -621,7 +623,7 @@ export class Client<
 	 * @returns The document with an ID matching the `id` parameter, if a matching
 	 *   document exists.
 	 */
-	async getByID<TDocument extends prismicT.PrismicDocument>(
+	async getByID<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		id: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<TDocument> {
@@ -653,7 +655,7 @@ export class Client<
 	 * @returns A paginated response containing documents with IDs matching the
 	 *   `ids` parameter.
 	 */
-	async getByIDs<TDocument extends prismicT.PrismicDocument>(
+	async getByIDs<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		ids: string[],
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<prismicT.Query<TDocument>> {
@@ -686,7 +688,7 @@ export class Client<
 	 *
 	 * @returns A list of documents with IDs matching the `ids` parameter.
 	 */
-	async getAllByIDs<TDocument extends prismicT.PrismicDocument>(
+	async getAllByIDs<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		ids: string[],
 		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
 	): Promise<TDocument[]> {
@@ -721,7 +723,7 @@ export class Client<
 		uid: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<DocumentTypeMap[DocumentType]>;
-	async getByUID<TDocument extends prismicT.PrismicDocument>(
+	async getByUID<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		documentType: string,
 		uid: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
@@ -763,7 +765,7 @@ export class Client<
 		uids: string[],
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<prismicT.Query<DocumentTypeMap[DocumentType]>>;
-	async getByUIDs<TDocument extends prismicT.PrismicDocument>(
+	async getByUIDs<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		documentType: string,
 		uids: string[],
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
@@ -806,7 +808,7 @@ export class Client<
 		uids: string[],
 		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
 	): Promise<DocumentTypeMap[DocumentType][]>;
-	async getAllByUIDs<TDocument extends prismicT.PrismicDocument>(
+	async getAllByUIDs<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		documentType: string,
 		uids: string[],
 		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
@@ -843,7 +845,7 @@ export class Client<
 		documentType: DocumentType,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<DocumentTypeMap[DocumentType]>;
-	async getSingle<TDocument extends prismicT.PrismicDocument>(
+	async getSingle<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		documentType: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<TDocument> {
@@ -874,7 +876,7 @@ export class Client<
 		documentType: DocumentType,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<prismicT.Query<DocumentTypeMap[DocumentType]>>;
-	async getByType<TDocument extends prismicT.PrismicDocument>(
+	async getByType<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		documentType: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<prismicT.Query<TDocument>> {
@@ -906,7 +908,7 @@ export class Client<
 			GetAllParams &
 			FetchParams,
 	): Promise<DocumentTypeMap[DocumentType][]>;
-	async getAllByType<TDocument extends prismicT.PrismicDocument>(
+	async getAllByType<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		documentType: string,
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
@@ -934,7 +936,7 @@ export class Client<
 	 *
 	 * @returns A paginated response containing documents with the tag.
 	 */
-	async getByTag<TDocument extends prismicT.PrismicDocument>(
+	async getByTag<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		tag: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<prismicT.Query<TDocument>> {
@@ -960,7 +962,7 @@ export class Client<
 	 *
 	 * @returns A list of all documents with the tag.
 	 */
-	async getAllByTag<TDocument extends prismicT.PrismicDocument>(
+	async getAllByTag<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		tag: string,
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
@@ -987,7 +989,7 @@ export class Client<
 	 *
 	 * @returns A paginated response containing documents with the tags.
 	 */
-	async getByEveryTag<TDocument extends prismicT.PrismicDocument>(
+	async getByEveryTag<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		tags: string[],
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<prismicT.Query<TDocument>> {
@@ -1014,7 +1016,9 @@ export class Client<
 	 *
 	 * @returns A list of all documents with the tags.
 	 */
-	async getAllByEveryTag<TDocument extends prismicT.PrismicDocument>(
+	async getAllByEveryTag<
+		TDocument extends DocumentTypeMap[keyof DocumentTypeMap],
+	>(
 		tags: string[],
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
@@ -1041,7 +1045,7 @@ export class Client<
 	 *
 	 * @returns A paginated response containing documents with at least one of the tags.
 	 */
-	async getBySomeTags<TDocument extends prismicT.PrismicDocument>(
+	async getBySomeTags<TDocument extends DocumentTypeMap[keyof DocumentTypeMap]>(
 		tags: string[],
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<prismicT.Query<TDocument>> {
@@ -1068,7 +1072,9 @@ export class Client<
 	 *
 	 * @returns A list of all documents with at least one of the tags.
 	 */
-	async getAllBySomeTags<TDocument extends prismicT.PrismicDocument>(
+	async getAllBySomeTags<
+		TDocument extends DocumentTypeMap[keyof DocumentTypeMap],
+	>(
 		tags: string[],
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,7 +15,7 @@ import {
 	AbortSignalLike,
 	FetchLike,
 	HttpRequestLike,
-	WeakExtract,
+	ExtractDocumentType,
 } from "./types";
 import { ForbiddenError } from "./ForbiddenError";
 import { NotFoundError } from "./NotFoundError";
@@ -713,17 +713,15 @@ export class Client<
 	 * @returns The document with a UID matching the `uid` parameter, if a
 	 *   matching document exists.
 	 */
-	getByUID<DocumentType extends TDocuments["type"]>(
-		documentType: DocumentType,
+	async getByUID<
+		TDocument extends TDocuments,
+		TDocumentType extends TDocument["type"] = TDocument["type"],
+	>(
+		documentType: TDocumentType,
 		uid: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<WeakExtract<TDocuments, { type: DocumentType }>>;
-	async getByUID<TDocument extends TDocuments>(
-		documentType: TDocument["type"],
-		uid: string,
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<TDocument> {
-		return await this.getFirst<TDocument>(
+	): Promise<ExtractDocumentType<TDocuments, TDocumentType>> {
+		return await this.getFirst<ExtractDocumentType<TDocuments, TDocumentType>>(
 			appendPredicates(params, [
 				typePredicate(documentType),
 				predicate.at(`my.${documentType}.uid`, uid),
@@ -755,17 +753,15 @@ export class Client<
 	 * @returns A paginated response containing documents with UIDs matching the
 	 *   `uids` parameter.
 	 */
-	getByUIDs<DocumentType extends TDocuments["type"]>(
-		documentType: DocumentType,
+	async getByUIDs<
+		TDocument extends TDocuments,
+		TDocumentType extends TDocument["type"] = TDocument["type"],
+	>(
+		documentType: TDocumentType,
 		uids: string[],
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<prismicT.Query<WeakExtract<TDocuments, { type: DocumentType }>>>;
-	async getByUIDs<TDocument extends TDocuments>(
-		documentType: TDocuments["type"],
-		uids: string[],
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<prismicT.Query<TDocument>> {
-		return await this.get<TDocument>(
+	): Promise<prismicT.Query<ExtractDocumentType<TDocuments, TDocumentType>>> {
+		return await this.get<ExtractDocumentType<TDocuments, TDocumentType>>(
 			appendPredicates(params, [
 				typePredicate(documentType),
 				predicate.in(`my.${documentType}.uid`, uids),
@@ -798,17 +794,17 @@ export class Client<
 	 *
 	 * @returns A list of documents with UIDs matching the `uids` parameter.
 	 */
-	getAllByUIDs<DocumentType extends TDocuments["type"]>(
-		documentType: DocumentType,
+	async getAllByUIDs<
+		TDocument extends TDocuments,
+		TDocumentType extends TDocument["type"] = TDocument["type"],
+	>(
+		documentType: TDocumentType,
 		uids: string[],
 		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
-	): Promise<WeakExtract<TDocuments, { type: DocumentType }>[]>;
-	async getAllByUIDs<TDocument extends TDocuments>(
-		documentType: TDocuments["type"],
-		uids: string[],
-		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
-	): Promise<TDocument[]> {
-		return await this.dangerouslyGetAll<TDocument>(
+	): Promise<ExtractDocumentType<TDocuments, TDocumentType>[]> {
+		return await this.dangerouslyGetAll<
+			ExtractDocumentType<TDocuments, TDocumentType>
+		>(
 			appendPredicates(params, [
 				typePredicate(documentType),
 				predicate.in(`my.${documentType}.uid`, uids),
@@ -836,15 +832,14 @@ export class Client<
 	 *
 	 * @returns The singleton document for the Custom Type, if a matching document exists.
 	 */
-	getSingle<DocumentType extends TDocuments["type"]>(
-		documentType: DocumentType,
+	async getSingle<
+		TDocument extends TDocuments,
+		TDocumentType extends TDocument["type"] = TDocument["type"],
+	>(
+		documentType: TDocumentType,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<WeakExtract<TDocuments, { type: DocumentType }>>;
-	async getSingle<TDocument extends TDocuments>(
-		documentType: TDocuments["type"],
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<TDocument> {
-		return await this.getFirst<TDocument>(
+	): Promise<ExtractDocumentType<TDocuments, TDocumentType>> {
+		return await this.getFirst<ExtractDocumentType<TDocuments, TDocumentType>>(
 			appendPredicates(params, typePredicate(documentType)),
 		);
 	}
@@ -867,15 +862,14 @@ export class Client<
 	 *
 	 * @returns A paginated response containing documents of the Custom Type.
 	 */
-	getByType<DocumentType extends TDocuments["type"]>(
-		documentType: DocumentType,
+	async getByType<
+		TDocument extends TDocuments,
+		TDocumentType extends TDocument["type"] = TDocument["type"],
+	>(
+		documentType: TDocumentType,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<prismicT.Query<WeakExtract<TDocuments, { type: DocumentType }>>>;
-	async getByType<TDocument extends TDocuments>(
-		documentType: TDocuments["type"],
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<prismicT.Query<TDocument>> {
-		return await this.get<TDocument>(
+	): Promise<prismicT.Query<ExtractDocumentType<TDocuments, TDocumentType>>> {
+		return await this.get<ExtractDocumentType<TDocuments, TDocumentType>>(
 			appendPredicates(params, typePredicate(documentType)),
 		);
 	}
@@ -897,21 +891,18 @@ export class Client<
 	 *
 	 * @returns A list of all documents of the Custom Type.
 	 */
-	getAllByType<DocumentType extends TDocuments["type"]>(
-		documentType: DocumentType,
+	async getAllByType<
+		TDocument extends TDocuments,
+		TDocumentType extends TDocument["type"] = TDocument["type"],
+	>(
+		documentType: TDocumentType,
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
 			FetchParams,
-	): Promise<WeakExtract<TDocuments, { type: DocumentType }>[]>;
-	async getAllByType<TDocument extends TDocuments>(
-		documentType: TDocuments["type"],
-		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
-			GetAllParams &
-			FetchParams,
-	): Promise<TDocument[]> {
-		return await this.dangerouslyGetAll<TDocument>(
-			appendPredicates(params, typePredicate(documentType)),
-		);
+	): Promise<ExtractDocumentType<TDocuments, TDocumentType>[]> {
+		return await this.dangerouslyGetAll<
+			ExtractDocumentType<TDocuments, TDocumentType>
+		>(appendPredicates(params, typePredicate(documentType)));
 	}
 
 	/**

--- a/src/client.ts
+++ b/src/client.ts
@@ -237,6 +237,21 @@ const someTagsPredicate = (tags: string | string[]): string =>
 	predicate.any("document.tags", castArray(tags));
 
 /**
+ * Type definitions for the `createClient()` function. May be augmented by
+ * third-party libraries.
+ */
+export interface CreateClient {
+	<
+		DocumentTypeMap extends Record<string, prismicT.PrismicDocument> = Record<
+			string,
+			prismicT.PrismicDocument
+		>,
+	>(
+		...args: ConstructorParameters<typeof Client>
+	): Client<DocumentTypeMap>;
+}
+
+/**
  * Creates a Prismic client that can be used to query a repository.
  *
  * @example
@@ -256,9 +271,12 @@ const someTagsPredicate = (tags: string | string[]): string =>
  *
  * @returns A client that can query content from the repository.
  */
-export const createClient = (
-	...args: ConstructorParameters<typeof Client>
-): Client => new Client(...args);
+export const createClient: CreateClient = <
+	DocumentTypeMap extends Record<string, prismicT.PrismicDocument>,
+>(
+	repositoryNameOrEndpoint: string,
+	options: ClientConfig = {},
+) => new Client<DocumentTypeMap>(repositoryNameOrEndpoint, options);
 
 /**
  * A client that allows querying content from a Prismic repository.
@@ -267,7 +285,12 @@ export const createClient = (
  * such as Node.js, the `fetch` option must be provided as part of the `options`
  * parameter.
  */
-export class Client {
+export class Client<
+	DocumentTypeMap extends Record<string, prismicT.PrismicDocument> = Record<
+		string,
+		prismicT.PrismicDocument
+	>,
+> {
 	/**
 	 * The Prismic REST API V2 endpoint for the repository (use
 	 * `prismic.getRepositoryEndpoint` for the default endpoint).
@@ -688,6 +711,11 @@ export class Client {
 	 * @returns The document with a UID matching the `uid` parameter, if a
 	 *   matching document exists.
 	 */
+	getByUID<DocumentType extends keyof DocumentTypeMap>(
+		documentType: DocumentType,
+		uid: string,
+		params?: Partial<BuildQueryURLArgs> & FetchParams,
+	): Promise<DocumentTypeMap[DocumentType]>;
 	async getByUID<TDocument extends prismicT.PrismicDocument>(
 		documentType: string,
 		uid: string,
@@ -725,6 +753,11 @@ export class Client {
 	 * @returns A paginated response containing documents with UIDs matching the
 	 *   `uids` parameter.
 	 */
+	getByUIDs<DocumentType extends keyof DocumentTypeMap>(
+		documentType: DocumentType,
+		uids: string[],
+		params?: Partial<BuildQueryURLArgs> & FetchParams,
+	): Promise<prismicT.Query<DocumentTypeMap[DocumentType]>>;
 	async getByUIDs<TDocument extends prismicT.PrismicDocument>(
 		documentType: string,
 		uids: string[],
@@ -763,6 +796,11 @@ export class Client {
 	 *
 	 * @returns A list of documents with UIDs matching the `uids` parameter.
 	 */
+	getAllByUIDs<DocumentType extends keyof DocumentTypeMap>(
+		documentType: DocumentType,
+		uids: string[],
+		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
+	): Promise<DocumentTypeMap[DocumentType][]>;
 	async getAllByUIDs<TDocument extends prismicT.PrismicDocument>(
 		documentType: string,
 		uids: string[],
@@ -796,6 +834,10 @@ export class Client {
 	 *
 	 * @returns The singleton document for the Custom Type, if a matching document exists.
 	 */
+	getSingle<DocumentType extends keyof DocumentTypeMap>(
+		documentType: DocumentType,
+		params?: Partial<BuildQueryURLArgs> & FetchParams,
+	): Promise<DocumentTypeMap[DocumentType]>;
 	async getSingle<TDocument extends prismicT.PrismicDocument>(
 		documentType: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
@@ -823,6 +865,10 @@ export class Client {
 	 *
 	 * @returns A paginated response containing documents of the Custom Type.
 	 */
+	getByType<DocumentType extends keyof DocumentTypeMap>(
+		documentType: DocumentType,
+		params?: Partial<BuildQueryURLArgs> & FetchParams,
+	): Promise<prismicT.Query<DocumentTypeMap[DocumentType]>>;
 	async getByType<TDocument extends prismicT.PrismicDocument>(
 		documentType: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
@@ -849,6 +895,12 @@ export class Client {
 	 *
 	 * @returns A list of all documents of the Custom Type.
 	 */
+	getAllByType<DocumentType extends keyof DocumentTypeMap>(
+		documentType: DocumentType,
+		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
+			GetAllParams &
+			FetchParams,
+	): Promise<DocumentTypeMap[DocumentType][]>;
 	async getAllByType<TDocument extends prismicT.PrismicDocument>(
 		documentType: string,
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &

--- a/src/client.ts
+++ b/src/client.ts
@@ -264,6 +264,8 @@ export interface CreateClient {
  * createClient("https://qwerty.cdn.prismic.io/api/v2");
  * ```
  *
+ * @typeParam DocumentTypeMap - A map of Prismic document type IDs mapped to
+ *   their TypeScript type.
  * @param repositoryNameOrEndpoint - The Prismic repository name or full Rest
  *   API V2 endpoint for the repository.
  * @param options - Configuration that determines how content will be queried
@@ -284,6 +286,9 @@ export const createClient: CreateClient = <
  * If used in an environment where a global `fetch` function is unavailable,
  * such as Node.js, the `fetch` option must be provided as part of the `options`
  * parameter.
+ *
+ * @typeParam DocumentTypeMap - A map of Prismic document type IDs mapped to
+ *   their TypeScript type.
  */
 export class Client<
 	DocumentTypeMap extends Record<string, prismicT.PrismicDocument> = Record<

--- a/src/client.ts
+++ b/src/client.ts
@@ -275,7 +275,7 @@ export const createClient: CreateClient = <
 	DocumentTypeMap extends Record<string, prismicT.PrismicDocument>,
 >(
 	repositoryNameOrEndpoint: string,
-	options: ClientConfig = {},
+	options?: ClientConfig,
 ) => new Client<DocumentTypeMap>(repositoryNameOrEndpoint, options);
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export { NotFoundError } from "./NotFoundError";
 export * as cookie from "./cookie";
 
 // General types used throughout the project. These are made public to allow users to better type their projects.
-export type { ClientConfig } from "./client";
+export type { CreateClient, ClientConfig } from "./client";
 export type { QueryParams, BuildQueryURLArgs } from "./buildQueryURL";
 export type {
 	FetchLike,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import * as prismicT from "@prismicio/types";
+
 /**
  * Create a union of the given object's values, and optionally specify which
  * keys to get the values from.
@@ -19,9 +21,9 @@ export type ValueOf<
  * @example
  *
  * ```ts
- * WeakExtract<"a" | "b", "a"> // => "a"
- * WeakExtract<"a" | "b", "c"> // => "a" | "b"
- * WeakExtract<"a" | "b", "c", "foo"> // => "foo"
+ * ExtractOrFallback<"a" | "b", "a"> // => "a"
+ * ExtractOrFallback<"a" | "b", "c"> // => "a" | "b"
+ * ExtractOrFallback<"a" | "b", "c", "foo"> // => "foo"
  * ```
  *
  * @typeParam T - The union from which values will be extracted.
@@ -29,9 +31,22 @@ export type ValueOf<
  * @typeParam Fallback - The value to return if the resulting union is `never`.
  *   Defaults to `T`.
  */
-export type WeakExtract<T, U, Fallback = T> = Extract<T, U> extends never
+type ExtractOrFallback<T, U, Fallback = T> = Extract<T, U> extends never
 	? Fallback
 	: Extract<T, U>;
+
+/**
+ * Extracts one or more Prismic document types that match a given Prismic
+ * document type. If no matches are found, no extraction is performed and the
+ * union of all provided Prismic document types are returned.
+ *
+ * @typeParam TDocuments - Prismic document types from which to extract.
+ * @typeParam TDocumentType - Type(s) to match `TDocuments` against.
+ */
+export type ExtractDocumentType<
+	TDocuments extends prismicT.PrismicDocument,
+	TDocumentType extends TDocuments["type"],
+> = ExtractOrFallback<TDocuments, { type: TDocumentType }>;
 
 /**
  * A universal API to make network requests. A subset of the `fetch()` API.

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,27 @@ export type ValueOf<
 > = ObjectType[ValueType];
 
 /**
+ * Functions like TypeScript's native `Extract` utility type with added support
+ * to fall back to a value if the resulting union is `never`.
+ *
+ * @example
+ *
+ * ```ts
+ * WeakExtract<"a" | "b", "a"> // => "a"
+ * WeakExtract<"a" | "b", "c"> // => "a" | "b"
+ * WeakExtract<"a" | "b", "c", "foo"> // => "foo"
+ * ```
+ *
+ * @typeParam T - The union from which values will be extracted.
+ * @typeParam U - The extraction condition.
+ * @typeParam Fallback - The value to return if the resulting union is `never`.
+ *   Defaults to `T`.
+ */
+export type WeakExtract<T, U, Fallback = T> = Extract<T, U> extends never
+	? Fallback
+	: Extract<T, U>;
+
+/**
  * A universal API to make network requests. A subset of the `fetch()` API.
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/fetch}

--- a/test/__testutils__/createClient.ts
+++ b/test/__testutils__/createClient.ts
@@ -1,16 +1,17 @@
 import * as ava from "ava";
 import * as crypto from "crypto";
+import * as prismicT from "@prismicio/types";
 
 import * as prismic from "../../src";
 
-export const createTestClient = (
+export const createTestClient = <TDocuments extends prismicT.PrismicDocument>(
 	t: ava.ExecutionContext,
 	options?: prismic.ClientConfig,
-): prismic.Client => {
+): prismic.Client<TDocuments> => {
 	const repositoryName = crypto.createHash("md5").update(t.title).digest("hex");
 	const endpoint = `https://${repositoryName}.cdn.prismic.io/api/v2`;
 
-	return prismic.createClient(endpoint, {
+	return prismic.createClient<TDocuments>(endpoint, {
 		fetch: (...args) =>
 			import("node-fetch").then(({ default: fetch }) => fetch(...args)),
 		...options,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds the ability to declare document types queryable by the client.

Client methods that accept an explicit document type, such as `getByType()` and `getSingle()`, can automatically return the appropriate document type. Furthermore, these methods are typed to only accept document type IDs that have been provided to the client.

```typescript
import * as prismic from "@prismicio/client";
import * as prismicT from "@prismicio/types";

type PageDocument = prismicT.PrismicDocument<
  { foo: prismicT.KeyTextField },
  "page"
>;

type SettingsDocument = prismicT.PrismicDocument<
  { bar: prismicT.BooleanField },
  "settings"
>;

type AllDocumentTypes = PageDocument | SettingsDocument;

const client = prismic.createClient<AllDocumentTypes>("qwerty");
//    ^ Contains references to document types

const home = await client.getByUID("page", "home");
//    ^ Typed as PageDocument

home.data.foo;
//        ^ Typed as KeyTextField

const settings = await client.getSingle("settings");
//    ^ Typed as SettingsDocument

const foo = await client.getByType("foo");
// Type error - argument of type "foo" is not assignable to parameter of type "page" | "settings"
```

Methods that do not explicitly accept a document type return a union of all possible document types. Documents can be type narrowed at runtime by checking their `type` property.

```typescript
const client = prismic.createClient<AllDocumentTypes>("qwerty");

const doc = await client.getFirst();
//    ^ Typed as PageDocument | SettingsDocument
```

### Maintaining backwards compatibility

Query methods still accept a `DocumentType` type parameter to explicitly declare the returned document type. This is useful if types were not provided to `createClient()` or the document type passed to a query method is not a constant (i.e. typed as `string`).

**Backwards compatibility is maintained compared to the previous TypeScript API.**

```typescript
const client = prismic.createClient("qwerty");

const homeWithoutType = await client.getByUID("page", "home");
//    ^ Typed as prismicT.PrismicDocument (i.e. a generic document)

const homeWithType = await client.getByUID<PageDocument>("page", "home");
//    ^ Typed as PageDocument
```

If types are provided to `createClient()`, explitly provided document types to a query method must be assignable to the client-level types.

```typescript
type FooDocument = prismicT.PrismicDocument<
  { baz: prismicT.BooleanField },
  "foo"
>;

const client = prismic.createClient<PageDocument | SettingsDocument>("qwerty");

const foo = await client.getSingle<FooDocument>("settings");
// Type error - FooDocument is not assignable to PageDocument | SettingsDocument
```

### Client type augmentation

This PR also adds the ability for `createClient()` type augmentation through a new `CreateClient` interface. This lets third-party packages, such as those generating types, to automatically link a literal repository name to a set of document types.

```typescript
// prismic-client.d.ts
import * as prismic from "@prismicio/client";
import * as prismicT from "@prismicio/types";

type PageDocument = prismicT.PrismicDocument<
  { foo: prismicT.KeyTextField },
  "page"
>;

type SettingsDocument = prismicT.PrismicDocument<
  { bar: prismicT.Boolean },
  "settings"
>;

type AllDocumentTypes = PageDocument | SettingsDocument;

declare module "@prismicio/client" {
  interface CreateClient {
    (
      repositoryNameOrEndpoint: "qwerty",
      options?: prismic.ClientConfig | undefined
    ): prismic.Client<AllDocumentTypes>;
  }
}
```

With this module augmentation in place, `createClient("qwerty")` will automatically use `AllDocumentTypes`.

```typescript
import * as prismic from "@prismicio/client";

const client = prismic.createClient("qwerty");
//    ^ Contains references to document types

const home = await client.getByUID("page", "home");
//    ^ Typed as PageDocument

home.data.foo;
//        ^ typed as KeyTextField
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦑
