### PR TITLE
feat: accept Web API Request object in `enableAutoPreviewsFromReq()`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1492,15 +1492,24 @@ export class Client {
 	 */
 	private async getResolvedRefString(params?: FetchParams): Promise<string> {
 		if (this.refState.autoPreviewsEnabled) {
-			let previewRef: string | undefined = undefined;
+			let previewRef: string | undefined;
+
+			let cookieJar: string | null | undefined;
 
 			if (globalThis.document?.cookie) {
-				previewRef = getCookie(cookie.preview, globalThis.document.cookie);
-			} else if (this.refState.httpRequest?.headers?.cookie) {
-				previewRef = getCookie(
-					cookie.preview,
-					this.refState.httpRequest.headers.cookie,
-				);
+				cookieJar = globalThis.document.cookie;
+			} else if (this.refState.httpRequest?.headers) {
+				if ("get" in this.refState.httpRequest?.headers) {
+					// Web API Headers
+					cookieJar = this.refState.httpRequest.headers.get("cookie");
+				} else {
+					// Express-style headers
+					cookieJar = this.refState.httpRequest.headers.cookie;
+				}
+			}
+
+			if (cookieJar) {
+				previewRef = getCookie(cookie.preview, cookieJar);
 			}
 
 			if (previewRef) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1216,7 +1216,7 @@ export class Client {
 			documentID = documentID || searchParams.get("documentId");
 			previewToken = previewToken || searchParams.get("token");
 		} else if (this.refState.httpRequest) {
-			if ("url" in this.refState.httpRequest) {
+			if (this.refState.httpRequest.url) {
 				const searchParams = new URL(this.refState.httpRequest.url)
 					.searchParams;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1507,10 +1507,13 @@ export class Client {
 			if (globalThis.document?.cookie) {
 				cookieJar = globalThis.document.cookie;
 			} else if (this.refState.httpRequest?.headers) {
-				if ("get" in this.refState.httpRequest?.headers) {
+				if (
+					"get" in this.refState.httpRequest?.headers &&
+					typeof this.refState.httpRequest.headers.get === "function"
+				) {
 					// Web API Headers
 					cookieJar = this.refState.httpRequest.headers.get("cookie");
-				} else {
+				} else if ("cookie" in this.refState.httpRequest.headers) {
 					// Express-style headers
 					cookieJar = this.refState.httpRequest.headers.cookie;
 				}

--- a/src/client.ts
+++ b/src/client.ts
@@ -1207,19 +1207,27 @@ export class Client {
 	async resolvePreviewURL<LinkResolverReturnType>(
 		args: ResolvePreviewArgs<LinkResolverReturnType> & FetchParams,
 	): Promise<string> {
-		let documentID = args.documentID;
-		let previewToken = args.previewToken;
+		let documentID: string | undefined | null = args.documentID;
+		let previewToken: string | undefined | null = args.previewToken;
 
 		if (typeof globalThis.location !== "undefined") {
 			const searchParams = new URLSearchParams(globalThis.location.search);
 
-			documentID = documentID || searchParams.get("documentId") || undefined;
-			previewToken = previewToken || searchParams.get("token") || undefined;
-		} else if (this.refState.httpRequest?.query) {
-			documentID =
-				documentID || (this.refState.httpRequest.query.documentId as string);
-			previewToken =
-				previewToken || (this.refState.httpRequest.query.token as string);
+			documentID = documentID || searchParams.get("documentId");
+			previewToken = previewToken || searchParams.get("token");
+		} else if (this.refState.httpRequest) {
+			if ("url" in this.refState.httpRequest) {
+				const searchParams = new URL(this.refState.httpRequest.url)
+					.searchParams;
+
+				documentID = documentID || searchParams.get("documentId");
+				previewToken = previewToken || searchParams.get("token");
+			} else {
+				documentID =
+					documentID || (this.refState.httpRequest.query?.documentId as string);
+				previewToken =
+					previewToken || (this.refState.httpRequest.query?.token as string);
+			}
 		}
 
 		if (documentID != null && previewToken != null) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1508,7 +1508,7 @@ export class Client {
 				cookieJar = globalThis.document.cookie;
 			} else if (this.refState.httpRequest?.headers) {
 				if (
-					"get" in this.refState.httpRequest?.headers &&
+					"get" in this.refState.httpRequest.headers &&
 					typeof this.refState.httpRequest.headers.get === "function"
 				) {
 					// Web API Headers

--- a/src/lib/getCookie.ts
+++ b/src/lib/getCookie.ts
@@ -47,12 +47,12 @@ const getAll = (cookieStore: string): { [name: string]: string } =>
 /**
  * Returns the value of a cookie from a given cookie store.
  *
- * @param Name - Of the cookie.
- * @param cookieStore - The stringified cookie store from which to read the cookie.
+ * @param name - Of the cookie.
+ * @param cookieJar - The stringified cookie store from which to read the cookie.
  *
  * @returns The value of the cookie, if it exists.
  */
 export const getCookie = (
 	name: string,
-	cookieStore: string,
-): string | undefined => getAll(cookieStore)[name];
+	cookieJar: string,
+): string | undefined => getAll(cookieJar)[name];

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,9 +69,14 @@ export interface ResponseLike {
  * Prismic preview support.
  */
 export interface HttpRequestLike {
-	headers?: {
-		cookie?: string;
-	};
+	headers?: // Web API Headers
+	| {
+				get(name: string): string | null;
+		  }
+		// Express-style headers (pre-parsed)
+		| {
+				cookie?: string;
+		  };
 	query?: Record<string, unknown>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,20 +65,34 @@ export interface ResponseLike {
 }
 
 /**
+ * The minimum required properties to treat as a Express-style Request for
+ * automatic Prismic preview support.
+ */
+type HttpRequestLikeExpress = {
+	headers?: {
+		cookie?: string;
+	};
+	query?: Record<string, unknown>;
+};
+
+/**
+ * The minimum required properties to treat as a Web API Request for automatic
+ * Prismic preview support.
+ *
+ * @see http://developer.mozilla.org/en-US/docs/Web/API/Request
+ */
+type HttpRequestLikeWebAPI = {
+	headers: {
+		get(name: string): string | null;
+	};
+	url: string;
+};
+
+/**
  * The minimum required properties to treat as an HTTP Request for automatic
  * Prismic preview support.
  */
-export interface HttpRequestLike {
-	headers?: // Web API Headers
-	| {
-				get(name: string): string | null;
-		  }
-		// Express-style headers (pre-parsed)
-		| {
-				cookie?: string;
-		  };
-	query?: Record<string, unknown>;
-}
+export type HttpRequestLike = HttpRequestLikeExpress | HttpRequestLikeWebAPI;
 
 /**
  * An `orderings` parameter that orders the results by the specified field.

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,34 +65,33 @@ export interface ResponseLike {
 }
 
 /**
- * The minimum required properties to treat as a Express-style Request for
- * automatic Prismic preview support.
- */
-type HttpRequestLikeExpress = {
-	headers?: {
-		cookie?: string;
-	};
-	query?: Record<string, unknown>;
-};
-
-/**
- * The minimum required properties to treat as a Web API Request for automatic
- * Prismic preview support.
- *
- * @see http://developer.mozilla.org/en-US/docs/Web/API/Request
- */
-type HttpRequestLikeWebAPI = {
-	headers: {
-		get(name: string): string | null;
-	};
-	url: string;
-};
-
-/**
  * The minimum required properties to treat as an HTTP Request for automatic
  * Prismic preview support.
  */
-export type HttpRequestLike = HttpRequestLikeExpress | HttpRequestLikeWebAPI;
+export type HttpRequestLike =
+	| /**
+	 * Web API Request
+	 *
+	 * @see http://developer.mozilla.org/en-US/docs/Web/API/Request
+	 */
+	{
+			headers?: {
+				get(name: string): string | null;
+			};
+			url?: string;
+			query?: never;
+	  }
+
+	/**
+	 * Express-style Request
+	 */
+	| {
+			headers?: {
+				cookie?: string;
+			};
+			query?: Record<string, unknown>;
+			url?: never;
+	  };
 
 /**
  * An `orderings` parameter that orders the results by the specified field.

--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -178,7 +178,7 @@ test.serial(
 	"returns defaultURL if req does not contain preview params in server req object",
 	async (t) => {
 		const defaultURL = "defaultURL";
-		const req = { query: {} };
+		const req = {};
 
 		const client = createTestClient(t);
 		client.enableAutoPreviewsFromReq(req);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -267,6 +267,7 @@ test.serial("supports req with Web APIs", async (t) => {
 	headers.set("cookie", `io.prismic.preview=${previewRef}`);
 	const req = {
 		headers,
+		url: "https://example.com",
 	};
 
 	const queryResponse = createQueryResponse();

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -286,6 +286,28 @@ test.serial("supports req with Web APIs", async (t) => {
 	t.deepEqual(res, queryResponse);
 });
 
+test.serial("ignores req without cookies", async (t) => {
+	const req = {
+		headers: {},
+	};
+
+	const repositoryResponse = createRepositoryResponse();
+	const queryResponse = createQueryResponse();
+
+	server.use(
+		createMockRepositoryHandler(t, repositoryResponse),
+		createMockQueryHandler(t, [queryResponse], undefined, {
+			ref: getMasterRef(repositoryResponse),
+		}),
+	);
+
+	const client = createTestClient(t);
+	client.enableAutoPreviewsFromReq(req);
+	const res = await client.get();
+
+	t.deepEqual(res, queryResponse);
+});
+
 test.serial(
 	"does not use preview ref if auto previews are disabled",
 	async (t) => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -286,6 +286,34 @@ test.serial("supports req with Web APIs", async (t) => {
 	t.deepEqual(res, queryResponse);
 });
 
+test.serial(
+	"correctly treats Express-style req with a Web API Headers-like shape",
+	async (t) => {
+		const previewRef = "previewRef";
+		const req = {
+			headers: {
+				get: "the get property also exists in the Web API Headers API",
+				cookie: `io.prismic.preview=${previewRef}`,
+			},
+		};
+
+		const queryResponse = createQueryResponse();
+
+		server.use(
+			createMockRepositoryHandler(t),
+			createMockQueryHandler(t, [queryResponse], undefined, {
+				ref: previewRef,
+			}),
+		);
+
+		const client = createTestClient(t);
+		client.enableAutoPreviewsFromReq(req);
+		const res = await client.get();
+
+		t.deepEqual(res, queryResponse);
+	},
+);
+
 test.serial("ignores req without cookies", async (t) => {
 	const req = {
 		headers: {},

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -286,34 +286,6 @@ test.serial("supports req with Web APIs", async (t) => {
 	t.deepEqual(res, queryResponse);
 });
 
-test.serial(
-	"correctly treats Express-style req with a Web API Headers-like shape",
-	async (t) => {
-		const previewRef = "previewRef";
-		const req = {
-			headers: {
-				get: "the get property also exists in the Web API Headers API",
-				cookie: `io.prismic.preview=${previewRef}`,
-			},
-		};
-
-		const queryResponse = createQueryResponse();
-
-		server.use(
-			createMockRepositoryHandler(t),
-			createMockQueryHandler(t, [queryResponse], undefined, {
-				ref: previewRef,
-			}),
-		);
-
-		const client = createTestClient(t);
-		client.enableAutoPreviewsFromReq(req);
-		const res = await client.get();
-
-		t.deepEqual(res, queryResponse);
-	},
-);
-
 test.serial("ignores req without cookies", async (t) => {
 	const req = {
 		headers: {},

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,7 +2,7 @@ import test from "ava";
 import * as msw from "msw";
 import * as mswNode from "msw/node";
 import * as sinon from "sinon";
-import { Response } from "node-fetch";
+import { Response, Headers } from "node-fetch";
 
 import { createMockQueryHandler } from "./__testutils__/createMockQueryHandler";
 import { createMockRepositoryHandler } from "./__testutils__/createMockRepositoryHandler";
@@ -243,6 +243,30 @@ test.serial("uses req preview ref if available", async (t) => {
 		headers: {
 			cookie: `io.prismic.preview=${previewRef}`,
 		},
+	};
+
+	const queryResponse = createQueryResponse();
+
+	server.use(
+		createMockRepositoryHandler(t),
+		createMockQueryHandler(t, [queryResponse], undefined, {
+			ref: previewRef,
+		}),
+	);
+
+	const client = createTestClient(t);
+	client.enableAutoPreviewsFromReq(req);
+	const res = await client.get();
+
+	t.deepEqual(res, queryResponse);
+});
+
+test.serial("supports req with Web APIs", async (t) => {
+	const previewRef = "previewRef";
+	const headers = new Headers();
+	headers.set("cookie", `io.prismic.preview=${previewRef}`);
+	const req = {
+		headers,
 	};
 
 	const queryResponse = createQueryResponse();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for [Web API Request](http://developer.mozilla.org/en-US/docs/Web/API/Request) objects containing a [Web API Headers](http://developer.mozilla.org/en-US/docs/Web/API/Headers) instance. Frameworks like SvelteKit use this API rather than an Express-style request object which, unlike the Web API counterpart, contains plain-object-based data.

```typescript
import * as prismic from "@prismicio/client";

const headers = new Headers();
headers.set("cookie", `io.prismic.preview=abc123`);

const request = {
  headers,
  url: 'https://example.com/preview?documentId=abc123&token=abc123'
};

const client = prismic.createClient("qwerty");
client.enableAutoPreviewsFromReq(request);

// The client will automatically read the `io.prismic.preview` cookie
// and URL parameters to enable preview sessions.
```

For more details, see #239.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦮
