### PR TITLE
fix: accept an array of strings when using the `not` predicate type

### DIFF
--- a/src/predicate.ts
+++ b/src/predicate.ts
@@ -104,11 +104,13 @@ export const predicate = {
 
 	/**
 	 * The `not` predicate checks that the path doesn't match the provided value
-	 * exactly. It takes a single value as the argument.
+	 * exactly. It takes a single value for a field or an array (only for tags).
 	 *
 	 * {@link https://prismic.io/docs/technologies/query-predicates-reference-rest-api#not}
 	 */
-	not: pathWithArgsPredicate<[value: string | number | boolean | Date]>("not"),
+	not: pathWithArgsPredicate<
+		[value: string | number | boolean | Date | string[]]
+	>("not"),
 
 	/**
 	 * The `any` predicate takes an array of values. It works exactly the same way

--- a/test/predicate-not.test.ts
+++ b/test/predicate-not.test.ts
@@ -11,6 +11,12 @@ test(
 );
 
 test(
+	'[not(document.tags, ["Macaron", "Cupcake"])]',
+	isTitleMacro,
+	prismic.predicate.not("document.tags", ["Macaron", "Cupcake"]),
+);
+
+test(
 	"[not(my.product.price, 50)]",
 	isTitleMacro,
 	prismic.predicate.not("my.product.price", 50),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
`not` predicate type was not aligned with API expectations, see: https://github.com/prismicio/prismic-types/issues/35
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
   PR: https://prismicio-docs-v3.prismic.io/documents~w=rest%20api%20technical&b=working&c=release%3AYo3rmxIAACMAlRcT&l=en-us/X7vlhRIAACYAdOzP/?section=Page%20Content
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
