### PR TITLE
fix: correctly detect HTTP requests with parsed queries

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1216,17 +1216,20 @@ export class Client {
 			documentID = documentID || searchParams.get("documentId");
 			previewToken = previewToken || searchParams.get("token");
 		} else if (this.refState.httpRequest) {
-			if (this.refState.httpRequest.url) {
+			if ("query" in this.refState.httpRequest) {
+				documentID =
+					documentID || (this.refState.httpRequest.query?.documentId as string);
+				previewToken =
+					previewToken || (this.refState.httpRequest.query?.token as string);
+			} else if (
+				"url" in this.refState.httpRequest &&
+				this.refState.httpRequest.url
+			) {
 				const searchParams = new URL(this.refState.httpRequest.url)
 					.searchParams;
 
 				documentID = documentID || searchParams.get("documentId");
 				previewToken = previewToken || searchParams.get("token");
-			} else {
-				documentID =
-					documentID || (this.refState.httpRequest.query?.documentId as string);
-				previewToken =
-					previewToken || (this.refState.httpRequest.query?.token as string);
 			}
 		}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,6 @@ export type HttpRequestLike =
 				get(name: string): string | null;
 			};
 			url?: string;
-			query?: never;
 	  }
 
 	/**
@@ -94,7 +93,6 @@ export type HttpRequestLike =
 				cookie?: string;
 			};
 			query?: Record<string, unknown>;
-			url?: never;
 	  };
 
 /**

--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -56,7 +56,12 @@ test.serial("resolves a preview url using a server req object", async (t) => {
 
 	const documentId = document.id;
 	const previewToken = "previewToken";
-	const req = { query: { documentId, token: previewToken } };
+	const req = {
+		query: { documentId, token: previewToken },
+		// This `url` property simulates a Next.js request. It is a
+		// partial URL only containing the pathname + search params.
+		url: `/foo?bar=baz`,
+	};
 
 	server.use(
 		createMockRepositoryHandler(t),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where Next.js requests were treated as Web API Requests. This caused the `resolvePreviewURL()` method to throw an error on this line:

https://github.com/prismicio/prismic-client/blob/7a1f2466d2a3e8060a85df8f2fc70aa6e56764aa/src/client.ts#L1220-L1221

In a Next.js request, the `url` property is not a valid URL; it is just the pathname and search params (e.g. `/foo?documentId=bar`).

In a Web API Request object, the `url` property is a valid URL.

(Thanks to @awilderink for pointing this out [here](https://github.com/prismicio/prismic-client/commit/66e01b96e377881e796ec5c034bd3e045bba43b6#r74896683).)

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
