### PR TITLE
fix: resolve issue where `getTags()` returned an empty array for secured repositories

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1150,7 +1150,13 @@ export class Client {
 		try {
 			const tagsForm = await this.getCachedRepositoryForm("tags", params);
 
-			return await this.fetch<string[]>(tagsForm.action);
+			const url = new URL(tagsForm.action);
+
+			if (this.accessToken) {
+				url.searchParams.set("access_token", this.accessToken);
+			}
+
+			return await this.fetch<string[]>(url.toString(), params);
 		} catch {
 			const repository = await this.getRepository(params);
 

--- a/test/client-getTags.test.ts
+++ b/test/client-getTags.test.ts
@@ -48,6 +48,36 @@ test("uses form endpoint if available", async (t) => {
 	t.deepEqual(res, tagsResponse);
 });
 
+test("sends access token if form endpoint is used", async (t) => {
+	const tagsEndpoint = "https://example.com/tags-form-endpoint";
+	const tagsResponse = ["foo", "bar"];
+	const accessToken = "accessToken";
+
+	const repositoryResponse = createRepositoryResponse({
+		forms: {
+			tags: {
+				method: "GET",
+				action: tagsEndpoint,
+				enctype: "",
+				fields: {},
+			},
+		},
+	});
+	server.use(
+		createMockRepositoryHandler(t, repositoryResponse),
+		msw.rest.get(tagsEndpoint, (req, res, ctx) => {
+			if (req.url.searchParams.get("access_token") === accessToken) {
+				return res(ctx.json(tagsResponse));
+			}
+		}),
+	);
+
+	const client = createTestClient(t, { accessToken });
+	const res = await client.getTags();
+
+	t.deepEqual(res, tagsResponse);
+});
+
 test("is abortable with an AbortController", async (t) => {
 	const repositoryResponse = createRepositoryResponse();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes an issue where a client's `getTags()` method could return an empty array (`[]`) rather than a list of the repository's tags. This could happen when a repository is proteted with an access token.

This happens because the client's access token was not being sent to the Tags API. This PR ensures the access token is sent if the Tags API is used.

Fixes #243

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐤
