### PR TITLE
fix: restore previous explicit document type paramter handling (fixes #246)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -720,8 +720,8 @@ export class Client<
 		documentType: TDocumentType,
 		uid: string,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<ExtractDocumentType<TDocuments, TDocumentType>> {
-		return await this.getFirst<ExtractDocumentType<TDocuments, TDocumentType>>(
+	): Promise<ExtractDocumentType<TDocument, TDocumentType>> {
+		return await this.getFirst<ExtractDocumentType<TDocument, TDocumentType>>(
 			appendPredicates(params, [
 				typePredicate(documentType),
 				predicate.at(`my.${documentType}.uid`, uid),
@@ -760,8 +760,8 @@ export class Client<
 		documentType: TDocumentType,
 		uids: string[],
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<prismicT.Query<ExtractDocumentType<TDocuments, TDocumentType>>> {
-		return await this.get<ExtractDocumentType<TDocuments, TDocumentType>>(
+	): Promise<prismicT.Query<ExtractDocumentType<TDocument, TDocumentType>>> {
+		return await this.get<ExtractDocumentType<TDocument, TDocumentType>>(
 			appendPredicates(params, [
 				typePredicate(documentType),
 				predicate.in(`my.${documentType}.uid`, uids),
@@ -801,9 +801,9 @@ export class Client<
 		documentType: TDocumentType,
 		uids: string[],
 		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
-	): Promise<ExtractDocumentType<TDocuments, TDocumentType>[]> {
+	): Promise<ExtractDocumentType<TDocument, TDocumentType>[]> {
 		return await this.dangerouslyGetAll<
-			ExtractDocumentType<TDocuments, TDocumentType>
+			ExtractDocumentType<TDocument, TDocumentType>
 		>(
 			appendPredicates(params, [
 				typePredicate(documentType),
@@ -838,8 +838,8 @@ export class Client<
 	>(
 		documentType: TDocumentType,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<ExtractDocumentType<TDocuments, TDocumentType>> {
-		return await this.getFirst<ExtractDocumentType<TDocuments, TDocumentType>>(
+	): Promise<ExtractDocumentType<TDocument, TDocumentType>> {
+		return await this.getFirst<ExtractDocumentType<TDocument, TDocumentType>>(
 			appendPredicates(params, typePredicate(documentType)),
 		);
 	}
@@ -868,8 +868,8 @@ export class Client<
 	>(
 		documentType: TDocumentType,
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
-	): Promise<prismicT.Query<ExtractDocumentType<TDocuments, TDocumentType>>> {
-		return await this.get<ExtractDocumentType<TDocuments, TDocumentType>>(
+	): Promise<prismicT.Query<ExtractDocumentType<TDocument, TDocumentType>>> {
+		return await this.get<ExtractDocumentType<TDocument, TDocumentType>>(
 			appendPredicates(params, typePredicate(documentType)),
 		);
 	}
@@ -899,9 +899,9 @@ export class Client<
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
 			FetchParams,
-	): Promise<ExtractDocumentType<TDocuments, TDocumentType>[]> {
+	): Promise<ExtractDocumentType<TDocument, TDocumentType>[]> {
 		return await this.dangerouslyGetAll<
-			ExtractDocumentType<TDocuments, TDocumentType>
+			ExtractDocumentType<TDocument, TDocumentType>
 		>(appendPredicates(params, typePredicate(documentType)));
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This fixes a regression introduced in #238 that prevented explicit doucment type parameters to be accepted. This includes cases that appear like the following:

```typescript
import * as prismic from "@prismicio/client";
import * as prismicT from "@prismicio/types";

type PageDocument = prismicT.PrismicDocument<
  { foo: prismicT.KeyTextField },
  "page"
>;

const client = prismic.createClient("qwerty");

const home = await client.getByUID<PageDocument>("page", "home");
//    ^ Typed as `PageDocument`
```

Before this PR, `home` would be typed as `prismicT.PrismicDocument` when it should be `PageDocument`.

Fixes #246

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
