### PR TITLE
refactor: optimize `getFirst()` and dependent methods

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -531,7 +531,12 @@ export class Client<
 	async getFirst<TDocument extends TDocuments>(
 		params?: Partial<BuildQueryURLArgs> & FetchParams,
 	): Promise<TDocument> {
-		const url = await this.buildQueryURL(params);
+		const url = await this.buildQueryURL({
+			pageSize:
+				this.defaultParams?.pageSize ||
+				(params && "page" in params ? undefined : 1),
+			...params,
+		});
 		const result = await this.fetch<prismicT.Query<TDocument>>(url, params);
 
 		const firstResult = result.results[0];

--- a/test/client-getByID.test.ts
+++ b/test/client-getByID.test.ts
@@ -26,6 +26,7 @@ test("queries for document by ID", async (t) => {
 		createMockQueryHandler(t, [queryResponse], undefined, {
 			ref: getMasterRef(repositoryResponse),
 			q: `[[at(document.id, "${document.id}")]]`,
+			pageSize: 1,
 		}),
 	);
 
@@ -51,6 +52,7 @@ test("includes params if provided", async (t) => {
 			ref: params.ref as string,
 			q: `[[at(document.id, "${document.id}")]]`,
 			lang: params.lang,
+			pageSize: 1,
 		}),
 	);
 

--- a/test/client-getByUID.test.ts
+++ b/test/client-getByUID.test.ts
@@ -29,6 +29,7 @@ test("queries for document by UID", async (t) => {
 				`[[at(document.type, "${document.type}")]]`,
 				`[[at(my.${document.type}.uid, "${document.uid}")]]`,
 			],
+			pageSize: 1,
 		}),
 	);
 
@@ -57,6 +58,7 @@ test("includes params if provided", async (t) => {
 				`[[at(my.${document.type}.uid, "${document.uid}")]]`,
 			],
 			lang: params.lang,
+			pageSize: 1,
 		}),
 	);
 

--- a/test/client-getSingle.test.ts
+++ b/test/client-getSingle.test.ts
@@ -26,6 +26,7 @@ test("queries for singleton document", async (t) => {
 		createMockQueryHandler(t, [queryResponse], undefined, {
 			ref: getMasterRef(repositoryResponse),
 			q: `[[at(document.type, "${document.type}")]]`,
+			pageSize: 1,
 		}),
 	);
 
@@ -51,6 +52,7 @@ test("includes params if provided", async (t) => {
 			ref: params.ref as string,
 			q: `[[at(document.type, "${document.type}")]]`,
 			lang: params.lang,
+			pageSize: 1,
 		}),
 	);
 

--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -35,6 +35,7 @@ test.serial("resolves a preview url in the browser", async (t) => {
 			ref: previewToken,
 			q: `[[at(document.id, "${documentId}")]]`,
 			lang: "*",
+			pageSize: 1,
 		}),
 	);
 
@@ -69,6 +70,7 @@ test.serial("resolves a preview url using a server req object", async (t) => {
 			ref: previewToken,
 			q: `[[at(document.id, "${documentId}")]]`,
 			lang: "*",
+			pageSize: 1,
 		}),
 	);
 
@@ -106,6 +108,7 @@ test.serial(
 				ref: previewToken,
 				q: `[[at(document.id, "${documentId}")]]`,
 				lang: "*",
+				pageSize: 1,
 			}),
 		);
 
@@ -141,6 +144,7 @@ test.serial(
 				ref: previewToken,
 				q: `[[at(document.id, "${documentID}")]]`,
 				lang: "*",
+				pageSize: 1,
 			}),
 		);
 
@@ -225,6 +229,7 @@ test.serial("returns defaultURL if resolved URL is not a string", async (t) => {
 			ref: previewToken,
 			q: `[[at(document.id, "${documentID}")]]`,
 			lang: "*",
+			pageSize: 1,
 		}),
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR optimizes `getFirst()` by defaulting to only query one document. It does this by setting `pageSize=1`.

The following methods also benefit from this optimization since they use `getFirst()` within their implementation:

- `getByID()`
- `getByUID()`
- `getSingle()`
- `resolvePreviewURL()`

**Exceptions to this optimization**:

- If a `page` param is provided, `pageSize` is not set. `pageSize` affects the behavior of `page`, so we cannot automatically set `pageSize` to 1.
- If a `pageSize` param is provided, it takes priority.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐥
