### PR TITLE
fix: adjust `AbortSignalLike` to support native `AbortSignal`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -392,7 +392,7 @@ export class Client<
 		if (typeof options.fetch === "function") {
 			this.fetchFn = options.fetch;
 		} else if (typeof globalThis.fetch === "function") {
-			this.fetchFn = globalThis.fetch;
+			this.fetchFn = globalThis.fetch as FetchLike;
 		} else {
 			throw new PrismicError(
 				"A valid fetch implementation was not provided. In environments where fetch is not available (including Node.js), a fetch implementation must be provided via a polyfill or the `fetch` option.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,10 +79,6 @@ export type AbortSignalLike = {
 	dispatchEvent: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	onabort: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	reason: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	throwIfAborted: any;
 };
 
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where `AbortSignalLike` was incompatible with the native `AbortSignal` type.

The following TypeScript error is emitted when using the native `AbortSignal` type:

```
[tsserver 2739] [E] Type 'AbortSignal' is missing the following properties from type 'AbortSignalLike': reason, throwIfAborted
```

### Background

`globalThis.fetch` uses an `AbortSignal` type within the `typescript/lib/lib.dom.d.ts` module that contains properties not present in the `@types/node/globals.d.ts` module. In practice, the wider type from `@types/node/global.d.ts` is sufficient and better integrates with real projects.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦆
