### PR TITLE
feat: support Route Resolver `uid`, `lang`, and `brokenRoute` options

### DIFF
--- a/src/buildQueryURL.ts
+++ b/src/buildQueryURL.ts
@@ -86,9 +86,10 @@ export interface QueryParams {
 	routes?: Route | string | (Route | string)[];
 
 	/**
-	 * The `brokenRoute` option allows you to define the default route broken Link
-	 * or content Relationship fields should use for their `url` field. A broken
-	 * link is a link whose linked document has been unpublished or deleted.
+	 * The `brokenRoute` option allows you to define the route populated in the
+	 * `url` property for broken Link or Content Relationship fields. A broken
+	 * link is a Link or Content Relationship field whose linked document has been
+	 * unpublished or deleted.
 	 *
 	 * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
 	 */

--- a/src/buildQueryURL.ts
+++ b/src/buildQueryURL.ts
@@ -84,6 +84,15 @@ export interface QueryParams {
 	 * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
 	 */
 	routes?: Route | string | (Route | string)[];
+
+	/**
+	 * The `brokenRoute` option allows you to define the default route broken Link
+	 * or content Relationship fields should use for their `url` field. A broken
+	 * link is a link whose linked document has been unpublished or deleted.
+	 *
+	 * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
+	 */
+	brokenRoute?: string;
 }
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -140,12 +140,21 @@ export type ClientConfig = {
 	routes?: NonNullable<BuildQueryURLArgs["routes"]>;
 
 	/**
+	 * The `brokenRoute` option allows you to define the default route broken Link
+	 * or content Relationship fields should use for their `url` field. A broken
+	 * link is a link whose linked document has been unpublished or deleted.
+	 *
+	 * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
+	 */
+	brokenRoute?: NonNullable<BuildQueryURLArgs["brokenRoute"]>;
+
+	/**
 	 * Default parameters that will be sent with each query. These parameters can
 	 * be overridden on each query if needed.
 	 */
 	defaultParams?: Omit<
 		BuildQueryURLArgs,
-		"ref" | "integrationFieldsRef" | "accessToken" | "routes"
+		"ref" | "integrationFieldsRef" | "accessToken" | "routes" | "brokenRoute"
 	>;
 
 	/**
@@ -315,6 +324,15 @@ export class Client<
 	routes?: NonNullable<BuildQueryURLArgs["routes"]>;
 
 	/**
+	 * The `brokenRoute` option allows you to define the default route broken Link
+	 * or content Relationship fields should use for their `url` field. A broken
+	 * link is a link whose linked document has been unpublished or deleted.
+	 *
+	 * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
+	 */
+	brokenRoute?: NonNullable<BuildQueryURLArgs["brokenRoute"]>;
+
+	/**
 	 * The function used to make network requests to the Prismic REST API. In
 	 * environments where a global `fetch` function does not exist, such as
 	 * Node.js, this function must be provided.
@@ -382,6 +400,7 @@ export class Client<
 
 		this.accessToken = options.accessToken;
 		this.routes = options.routes;
+		this.brokenRoute = options.brokenRoute;
 		this.defaultParams = options.defaultParams;
 
 		if (options.ref) {
@@ -1235,6 +1254,7 @@ export class Client<
 			ref,
 			integrationFieldsRef,
 			routes: params.routes || this.routes,
+			brokenRoute: params.brokenRoute || this.brokenRoute,
 			accessToken: params.accessToken || this.accessToken,
 		});
 	}

--- a/src/client.ts
+++ b/src/client.ts
@@ -140,9 +140,10 @@ export type ClientConfig = {
 	routes?: NonNullable<BuildQueryURLArgs["routes"]>;
 
 	/**
-	 * The `brokenRoute` option allows you to define the default route broken Link
-	 * or content Relationship fields should use for their `url` field. A broken
-	 * link is a link whose linked document has been unpublished or deleted.
+	 * The `brokenRoute` option allows you to define the route populated in the
+	 * `url` property for broken Link or Content Relationship fields. A broken
+	 * link is a Link or Content Relationship field whose linked document has been
+	 * unpublished or deleted.
 	 *
 	 * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
 	 */
@@ -324,9 +325,10 @@ export class Client<
 	routes?: NonNullable<BuildQueryURLArgs["routes"]>;
 
 	/**
-	 * The `brokenRoute` option allows you to define the default route broken Link
-	 * or content Relationship fields should use for their `url` field. A broken
-	 * link is a link whose linked document has been unpublished or deleted.
+	 * The `brokenRoute` option allows you to define the route populated in the
+	 * `url` property for broken Link or Content Relationship fields. A broken
+	 * link is a Link or Content Relationship field whose linked document has been
+	 * unpublished or deleted.
 	 *
 	 * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
 	 */

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,4 +47,6 @@ export type {
 	RequestInitLike,
 	ResponseLike,
 	Route,
+	RouteDefinition,
+	RouteBrokenDefinition,
 } from "./types";

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,4 @@ export type {
 	RequestInitLike,
 	ResponseLike,
 	Route,
-	RouteDefinition,
-	RouteBrokenDefinition,
 } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,13 +140,6 @@ export interface Ordering {
 /**
  * A `routes` parameter that determines how a document's URL field is resolved.
  *
- * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
- */
-export type Route = RouteDefinition | RouteBrokenDefinition;
-
-/**
- * A `routes` parameter that determines how a document's URL field is resolved.
- *
  * @example With a document's UID field.
  *
  * ```ts
@@ -170,7 +163,7 @@ export type Route = RouteDefinition | RouteBrokenDefinition;
  *
  * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
  */
-export type RouteDefinition = {
+export type Route = {
 	/**
 	 * The Custom Type of the document.
 	 */
@@ -178,9 +171,15 @@ export type RouteDefinition = {
 
 	/**
 	 * A specific UID to which this route definition is scoped. The route is only
-	 * defined for the given UID.
+	 * defined for the document of type matching the given UID.
 	 */
 	uid?: string;
+
+	/**
+	 * A specific lang to which this route definition is scoped. The route is only
+	 * defined for documents of type matching the given lang.
+	 */
+	lang?: string;
 
 	/**
 	 * The resolved path of the document with optional placeholders.
@@ -191,26 +190,4 @@ export type RouteDefinition = {
 	 * An object that lists the API IDs of the Content Relationships in the route.
 	 */
 	resolvers?: Record<string, string>;
-};
-
-/**
- * A `routes` parameter that determines how a broken Link or Content
- * Relationship field's URL is resolved. A broken link is a link whose linked
- * document has been unpublished or deleted.
- *
- * @example
- *
- * ```ts
- * {
- * 	"brokenRoute": "/404"
- * }
- * ```
- *
- * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
- */
-export type RouteBrokenDefinition = {
-	/**
-	 * The path to use when a document link is broken (i.e. the document no longer exists).
-	 */
-	brokenRoute: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,17 +142,75 @@ export interface Ordering {
  *
  * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
  */
-export interface Route {
+export type Route = RouteDefinition | RouteBrokenDefinition;
+
+/**
+ * A `routes` parameter that determines how a document's URL field is resolved.
+ *
+ * @example With a document's UID field.
+ *
+ * ```ts
+ * {
+ * 	"type": "page",
+ * 	"path": "/:uid"
+ * }
+ * ```
+ *
+ * @example With a Content Relationship `parent` field.
+ *
+ * ```ts
+ * {
+ * 	"type": "page",
+ * 	"path": "/:parent?/:uid",
+ * 	"resolvers": {
+ * 		"parent": "parent"
+ * 	}
+ * }
+ * ```
+ *
+ * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
+ */
+export type RouteDefinition = {
 	/**
 	 * The Custom Type of the document.
 	 */
 	type: string;
+
+	/**
+	 * A specific UID to which this route definition is scoped. The route is only
+	 * defined for the given UID.
+	 */
+	uid?: string;
+
 	/**
 	 * The resolved path of the document with optional placeholders.
 	 */
 	path: string;
+
 	/**
 	 * An object that lists the API IDs of the Content Relationships in the route.
 	 */
 	resolvers?: Record<string, string>;
-}
+};
+
+/**
+ * A `routes` parameter that determines how a broken Link or Content
+ * Relationship field's URL is resolved. A broken link is a link whose linked
+ * document has been unpublished or deleted.
+ *
+ * @example
+ *
+ * ```ts
+ * {
+ * 	"brokenRoute": "/404"
+ * }
+ * ```
+ *
+ * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
+ */
+export type RouteBrokenDefinition = {
+	/**
+	 * The path to use when a document link is broken (i.e. the document no longer exists).
+	 */
+	brokenRoute: string;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,7 +163,7 @@ export interface Ordering {
  *
  * {@link https://prismic.io/docs/core-concepts/link-resolver-route-resolver#route-resolver}
  */
-export type Route = {
+export interface Route {
 	/**
 	 * The Custom Type of the document.
 	 */
@@ -171,13 +171,13 @@ export type Route = {
 
 	/**
 	 * A specific UID to which this route definition is scoped. The route is only
-	 * defined for the document of type matching the given UID.
+	 * defined for the document whose UID matches the given UID.
 	 */
 	uid?: string;
 
 	/**
-	 * A specific lang to which this route definition is scoped. The route is only
-	 * defined for documents of type matching the given lang.
+	 * A specific language to which this route definition is scoped. The route is
+	 * only defined for documents whose language matches the given language.
 	 */
 	lang?: string;
 
@@ -190,4 +190,4 @@ export type Route = {
 	 * An object that lists the API IDs of the Content Relationships in the route.
 	 */
 	resolvers?: Record<string, string>;
-};
+}

--- a/test/buildQueryURL.test.ts
+++ b/test/buildQueryURL.test.ts
@@ -54,10 +54,11 @@ it("supports params", () => {
 				lang: "lang",
 				orderings: "orderings",
 				routes: "routes",
+				brokenRoute: "brokenRoute",
 			}),
 		),
 	).toBe(
-		"https://qwerty.cdn.prismic.io/api/v2/documents/search?ref=ref&access_token=accessToken&pageSize=1&page=1&after=after&fetch=fetch&fetchLinks=fetchLinks&graphQuery=graphQuery&lang=lang&orderings=[orderings]&routes=routes",
+		"https://qwerty.cdn.prismic.io/api/v2/documents/search?ref=ref&access_token=accessToken&pageSize=1&page=1&after=after&fetch=fetch&fetchLinks=fetchLinks&graphQuery=graphQuery&lang=lang&orderings=[orderings]&routes=routes&brokenRoute=brokenRoute",
 	);
 });
 

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -400,20 +400,41 @@ it("uses client-provided routes in queries", async (ctx) => {
 			path: "/",
 		},
 		{
-			brokenRoute: "/404",
+			type: "page",
+			uid: "home",
+			lang: "it-it",
+			path: "/it",
 		},
 	];
 
 	mockPrismicRestAPIV2({
 		queryResponse,
 		queryRequiredParams: {
-			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 			routes: JSON.stringify(routes),
 		},
 		ctx,
 	});
 
 	const client = createTestClient({ clientConfig: { routes } });
+	const res = await client.get();
+
+	expect(res).toStrictEqual(queryResponse);
+});
+
+it("uses client-provided brokenRoute in queries", async (ctx) => {
+	const queryResponse = prismicM.api.query({ seed: ctx.meta.name });
+
+	const brokenRoute = "/404";
+
+	mockPrismicRestAPIV2({
+		queryResponse,
+		queryRequiredParams: {
+			brokenRoute,
+		},
+		ctx,
+	});
+
+	const client = createTestClient({ clientConfig: { brokenRoute } });
 	const res = await client.get();
 
 	expect(res).toStrictEqual(queryResponse);

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -389,10 +389,18 @@ it("ignores the integration fields ref if the repository provides a null value",
 it("uses client-provided routes in queries", async (ctx) => {
 	const queryResponse = prismicM.api.query({ seed: ctx.meta.name });
 
-	const routes = [
+	const routes: prismic.Route[] = [
 		{
 			type: "page",
+			path: "/:uid",
+		},
+		{
+			type: "page",
+			uid: "home",
 			path: "/",
+		},
+		{
+			brokenRoute: "/404",
 		},
 	];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for Route Resolver's recently added `uid`, `lang`, and `brokenRoute` options. Route Resolver definitions can be provided to `@prismicio/client`'s `routes` option.

```typescript
import * as prismic from "@prismicio/client";

const client = prismic.createClient("your-repo-name", {
  routes: [
    {
      type: "page",
      uid: "home",
      path: "/",
    },
    {
      type: "page",
      path: "/:uid",
    },
  ],
  brokenRoute: "/404",
});
```

Closes #257.

### `uid` option

The `uid` option allows a route to be scoped to a document with a specific UID.

In the following example, a Page document with a UID of `home` will result in a `/` path. All other Page documents will use a computed path of `/:uid`.

```json
[
  {
    "type": "page",
    "uid": "home",
    "path": "/"
  },
  {
    "type": "page",
    "path": "/:uid"
  }
]
```

### `lang` option

The `lang` option allows a route to be scoped to a specific language.

In the following example, a Page document with a language of `fr-fr` will result in a `/fr/:uid` path. All other Page documents will use a computed path of `/:uid`.

```json
[
  {
    "type": "page",
    "lang": "fr-fr",
    "path": "/fr/:uid"
  },
  {
    "type": "page",
    "path": "/:uid"
  }
]
```

### `brokenRoute` option

The `brokenRoute` option allows a route to be defined for Link or Content Relationship fields where its linked document has since been unpublished or deleted.

The `brokenRoute` option is provided adjacent to the `routes` option.

In the following example, a Link field linked to a document that has been unpublished will have a `url` property of `/404`. Link fields whose documents have not been deleted will follow the other given route definitions.

```typescript
import * as prismic from "@prismicio/client";

const client = prismic.createClient("your-repo-name", {
  routes: [
    // List of routes...
  ],
  brokenRoute: "/404",
});
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🚓
