### PR TITLE
chore(deps): upgrade dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,30 +10,30 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@prismicio/helpers": "^2.3.3",
-				"@prismicio/types": "^0.2.1"
+				"@prismicio/types": "^0.2.3"
 			},
 			"devDependencies": {
 				"@prismicio/mock": "^0.1.1",
-				"@size-limit/preset-small-lib": "^8.0.0",
+				"@size-limit/preset-small-lib": "^8.0.1",
 				"@types/sinon": "^10.0.13",
-				"@typescript-eslint/eslint-plugin": "^5.32.0",
-				"@typescript-eslint/parser": "^5.32.0",
+				"@typescript-eslint/eslint-plugin": "^5.34.0",
+				"@typescript-eslint/parser": "^5.34.0",
+				"@vitest/coverage-c8": "^0.22.1",
 				"abort-controller": "^3.0.0",
-				"c8": "^7.12.0",
-				"eslint": "^8.21.0",
+				"eslint": "^8.22.0",
 				"eslint-config-prettier": "^8.5.0",
 				"eslint-plugin-prettier": "^4.2.1",
 				"eslint-plugin-tsdoc": "^0.2.16",
-				"msw": "^0.44.2",
+				"msw": "^0.45.0",
 				"node-fetch": "^3.2.10",
 				"nyc": "^15.1.0",
 				"prettier": "^2.7.1",
 				"prettier-plugin-jsdoc": "^0.3.38",
 				"siroc": "^0.16.0",
-				"size-limit": "^8.0.0",
+				"size-limit": "^8.0.1",
 				"standard-version": "^9.5.0",
 				"typescript": "^4.7.4",
-				"vitest": "^0.21.0"
+				"vitest": "^0.22.1"
 			},
 			"engines": {
 				"node": ">=12.13.0"
@@ -65,30 +65,30 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-			"integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
+			"integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-			"integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
+			"integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.18.13",
 				"@babel/helper-compilation-targets": "^7.18.9",
 				"@babel/helper-module-transforms": "^7.18.9",
 				"@babel/helpers": "^7.18.9",
-				"@babel/parser": "^7.18.10",
+				"@babel/parser": "^7.18.13",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.10",
-				"@babel/types": "^7.18.10",
+				"@babel/traverse": "^7.18.13",
+				"@babel/types": "^7.18.13",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -113,12 +113,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.18.12",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
-			"integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
+			"integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.18.10",
+				"@babel/types": "^7.18.13",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"jsesc": "^2.5.1"
 			},
@@ -383,9 +383,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-			"integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
+			"integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -409,19 +409,19 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-			"integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
+			"integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.18.13",
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-function-name": "^7.18.9",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.11",
-				"@babel/types": "^7.18.10",
+				"@babel/parser": "^7.18.13",
+				"@babel/types": "^7.18.13",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -439,9 +439,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-			"integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+			"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.18.10",
@@ -459,9 +459,9 @@
 			"dev": true
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.53.tgz",
-			"integrity": "sha512-W2dAL6Bnyn4xa/QRSU3ilIK4EzD5wgYXKXJiS1HDF5vU3675qc2bvFyLwbUcdmssDveyndy7FbitrCoiV/eMLg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.5.tgz",
+			"integrity": "sha512-UHkDFCfSGTuXq08oQltXxSZmH1TXyWsL+4QhZDWvvLl6mEJQqk3u7/wq1LjhrrAXYIllaTtRSzUXl4Olkf2J8A==",
 			"cpu": [
 				"loong64"
 			],
@@ -679,9 +679,9 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"version": "0.3.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+			"integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -720,9 +720,9 @@
 			}
 		},
 		"node_modules/@mswjs/interceptors": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.3.tgz",
-			"integrity": "sha512-jBRFPeHBPqKv3od8KPjmrvt4b/+e1DorizFDYJ8NQCrjFT9YGnxA8ojGi0MIo64x/JgdjYkhP8bG9EY4BGPoqg==",
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.4.tgz",
+			"integrity": "sha512-8oKWrOQ1P0Wj0kf3ak8WETuymknw2Tl2s1op8OzZctpNF3zSJSdEbcQs0pm347mwsM+95V6POBMv3W4812pEeg==",
 			"dev": true,
 			"dependencies": {
 				"@open-draft/until": "^1.0.3",
@@ -819,9 +819,9 @@
 			}
 		},
 		"node_modules/@prismicio/types": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.1.tgz",
-			"integrity": "sha512-FIj6trxFNlpO7WLYgV6UsURK6tAIXJPoFY9MuNW3eDcdw3he0C/aCRi57ApFiaIyroUSIajPNtWyMYzItD6wSg==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.3.tgz",
+			"integrity": "sha512-mHsZ9ora8He6PAn+Q/0MCVdlfc0Xv8rSEYJyfwywDApuvssGvgUbeHE6XTqPhK2dJwb0mAkJzCpZiQJRt9+bvw==",
 			"engines": {
 				"node": ">=12.7.0"
 			}
@@ -931,25 +931,25 @@
 			"dev": true
 		},
 		"node_modules/@size-limit/esbuild": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@size-limit/esbuild/-/esbuild-8.0.0.tgz",
-			"integrity": "sha512-du3gGKAzeh8fKEbqG0PcHKyyilpHTC+z/e6r0a82G+9KMCQd2PBHfOrTyN+of8u6EZXkrp0zdwgr84nKLp1nPg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@size-limit/esbuild/-/esbuild-8.0.1.tgz",
+			"integrity": "sha512-EnfRweoQc4P91G45sPfzAWMVPibK5SEV6sUWC46DcGlT9xrYeCQYtInbsny1/lSorC/sfJKN84aGm4A+q6SgOw==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.14.51",
+				"esbuild": "^0.15.1",
 				"nanoid": "^3.3.4"
 			},
 			"engines": {
 				"node": "^14.0.0 || ^16.0.0 || >=18.0.0"
 			},
 			"peerDependencies": {
-				"size-limit": "8.0.0"
+				"size-limit": "8.0.1"
 			}
 		},
 		"node_modules/@size-limit/file": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@size-limit/file/-/file-8.0.0.tgz",
-			"integrity": "sha512-xd4bBk/YyezsMQfpi2V3/blodCuPNVF5UwMd4L9LxBvon0PK4C1+3zBXxZpvN7AcMvPbJ8RUMS+iHpD4KcwaOg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@size-limit/file/-/file-8.0.1.tgz",
+			"integrity": "sha512-kwgc5UJQIz5qbRow3atSiW2K7vEIIw4DelT4WLn09cOwcJgWs82Imgz2UqVivHJmCisn/ltPjT4qmxaDfjFflw==",
 			"dev": true,
 			"dependencies": {
 				"semver": "7.3.7"
@@ -958,26 +958,26 @@
 				"node": "^14.0.0 || ^16.0.0 || >=18.0.0"
 			},
 			"peerDependencies": {
-				"size-limit": "8.0.0"
+				"size-limit": "8.0.1"
 			}
 		},
 		"node_modules/@size-limit/preset-small-lib": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@size-limit/preset-small-lib/-/preset-small-lib-8.0.0.tgz",
-			"integrity": "sha512-6Q2fJFuPalvANQIoxYAmQLGk1Rxerw/qtqpEi1dhF9czfWxtYxKwlVQgsE/d0j5eum/N7iJxioDeKZQJjzKPrQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@size-limit/preset-small-lib/-/preset-small-lib-8.0.1.tgz",
+			"integrity": "sha512-EV+UXGZJU9kiT8R4N9dxjRAJ37tzjuP+e2DfpRtv7cx1ErFiB6k//wEhw9nLmJMWWhfvcVEvJYyKm3+i0pbWUQ==",
 			"dev": true,
 			"dependencies": {
-				"@size-limit/esbuild": "8.0.0",
-				"@size-limit/file": "8.0.0"
+				"@size-limit/esbuild": "8.0.1",
+				"@size-limit/file": "8.0.1"
 			},
 			"peerDependencies": {
-				"size-limit": "8.0.0"
+				"size-limit": "8.0.1"
 			}
 		},
 		"node_modules/@types/chai": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
-			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
+			"integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
 			"dev": true
 		},
 		"node_modules/@types/chai-subset": {
@@ -1066,9 +1066,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.6.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-			"integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
+			"version": "18.7.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.10.tgz",
+			"integrity": "sha512-SST7B//wF7xlGoLo1IEVB0cQ4e7BgXlDk5IaPgb5s0DlYLjb4if07h8+0zbQIvahfPNXs6e7zyT0EH1MqaS+5g==",
 			"dev": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -1117,14 +1117,14 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-			"integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.34.0.tgz",
+			"integrity": "sha512-eRfPPcasO39iwjlUAMtjeueRGuIrW3TQ9WseIDl7i5UWuFbf83yYaU7YPs4j8+4CxUMIsj1k+4kV+E+G+6ypDQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/type-utils": "5.32.0",
-				"@typescript-eslint/utils": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.34.0",
+				"@typescript-eslint/type-utils": "5.34.0",
+				"@typescript-eslint/utils": "5.34.0",
 				"debug": "^4.3.4",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
@@ -1150,14 +1150,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
-			"integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.34.0.tgz",
+			"integrity": "sha512-SZ3NEnK4usd2CXkoV3jPa/vo1mWX1fqRyIVUQZR4As1vyp4fneknBNJj+OFtV8WAVgGf+rOHMSqQbs2Qn3nFZQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/typescript-estree": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.34.0",
+				"@typescript-eslint/types": "5.34.0",
+				"@typescript-eslint/typescript-estree": "5.34.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1177,13 +1177,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-			"integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.34.0.tgz",
+			"integrity": "sha512-HNvASMQlah5RsBW6L6c7IJ0vsm+8Sope/wu5sEAf7joJYWNb1LDbJipzmdhdUOnfrDFE6LR1j57x1EYVxrY4ow==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/visitor-keys": "5.32.0"
+				"@typescript-eslint/types": "5.34.0",
+				"@typescript-eslint/visitor-keys": "5.34.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1194,12 +1194,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-			"integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.34.0.tgz",
+			"integrity": "sha512-Pxlno9bjsQ7hs1pdWRUv9aJijGYPYsHpwMeCQ/Inavhym3/XaKt1ZKAA8FIw4odTBfowBdZJDMxf2aavyMDkLg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.32.0",
+				"@typescript-eslint/utils": "5.34.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			},
@@ -1220,9 +1220,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-			"integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.34.0.tgz",
+			"integrity": "sha512-49fm3xbbUPuzBIOcy2CDpYWqy/X7VBkxVN+DC21e0zIm3+61Z0NZi6J9mqPmSW1BDVk9FIOvuCFyUPjXz93sjA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1233,13 +1233,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-			"integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.34.0.tgz",
+			"integrity": "sha512-mXHAqapJJDVzxauEkfJI96j3D10sd567LlqroyCeJaHnu42sDbjxotGb3XFtGPYKPD9IyLjhsoULML1oI3M86A==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/visitor-keys": "5.32.0",
+				"@typescript-eslint/types": "5.34.0",
+				"@typescript-eslint/visitor-keys": "5.34.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -1260,15 +1260,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-			"integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.34.0.tgz",
+			"integrity": "sha512-kWRYybU4Rn++7lm9yu8pbuydRyQsHRoBDIo11k7eqBWTldN4xUdVUMCsHBiE7aoEkFzrUEaZy3iH477vr4xHAQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/typescript-estree": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.34.0",
+				"@typescript-eslint/types": "5.34.0",
+				"@typescript-eslint/typescript-estree": "5.34.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -1284,12 +1284,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-			"integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.34.0.tgz",
+			"integrity": "sha512-O1moYjOSrab0a2fUvFpsJe0QHtvTC+cR+ovYpgKrAVXzqQyc74mv76TgY6z+aEtjQE2vgZux3CQVtGryqdcOAw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/types": "5.34.0",
 				"eslint-visitor-keys": "^3.3.0"
 			},
 			"engines": {
@@ -1298,6 +1298,19 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@vitest/coverage-c8": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.22.1.tgz",
+			"integrity": "sha512-KOOYpO7EGpaF+nD8GD+Y05D0JtZp12NUu6DdLXvBPqSOPo2HkZ7KNBtfR0rb6gOy3NLtGiWTYTzCwhajgb2HlA==",
+			"dev": true,
+			"dependencies": {
+				"c8": "^7.12.0",
+				"vitest": "0.22.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
@@ -1779,9 +1792,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001374",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-			"integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
+			"version": "1.0.30001381",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz",
+			"integrity": "sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w==",
 			"dev": true,
 			"funding": [
 				{
@@ -2686,9 +2699,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.211",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-			"integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==",
+			"version": "1.4.225",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz",
+			"integrity": "sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -2767,9 +2780,9 @@
 			"dev": true
 		},
 		"node_modules/esbuild": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.53.tgz",
-			"integrity": "sha512-ohO33pUBQ64q6mmheX1mZ8mIXj8ivQY/L4oVuAshr+aJI+zLl+amrp3EodrUNDNYVrKJXGPfIHFGhO8slGRjuw==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.5.tgz",
+			"integrity": "sha512-VSf6S1QVqvxfIsSKb3UKr3VhUCis7wgDbtF4Vd9z84UJr05/Sp2fRKmzC+CSPG/dNAPPJZ0BTBLTT1Fhd6N9Gg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -2779,33 +2792,33 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"@esbuild/linux-loong64": "0.14.53",
-				"esbuild-android-64": "0.14.53",
-				"esbuild-android-arm64": "0.14.53",
-				"esbuild-darwin-64": "0.14.53",
-				"esbuild-darwin-arm64": "0.14.53",
-				"esbuild-freebsd-64": "0.14.53",
-				"esbuild-freebsd-arm64": "0.14.53",
-				"esbuild-linux-32": "0.14.53",
-				"esbuild-linux-64": "0.14.53",
-				"esbuild-linux-arm": "0.14.53",
-				"esbuild-linux-arm64": "0.14.53",
-				"esbuild-linux-mips64le": "0.14.53",
-				"esbuild-linux-ppc64le": "0.14.53",
-				"esbuild-linux-riscv64": "0.14.53",
-				"esbuild-linux-s390x": "0.14.53",
-				"esbuild-netbsd-64": "0.14.53",
-				"esbuild-openbsd-64": "0.14.53",
-				"esbuild-sunos-64": "0.14.53",
-				"esbuild-windows-32": "0.14.53",
-				"esbuild-windows-64": "0.14.53",
-				"esbuild-windows-arm64": "0.14.53"
+				"@esbuild/linux-loong64": "0.15.5",
+				"esbuild-android-64": "0.15.5",
+				"esbuild-android-arm64": "0.15.5",
+				"esbuild-darwin-64": "0.15.5",
+				"esbuild-darwin-arm64": "0.15.5",
+				"esbuild-freebsd-64": "0.15.5",
+				"esbuild-freebsd-arm64": "0.15.5",
+				"esbuild-linux-32": "0.15.5",
+				"esbuild-linux-64": "0.15.5",
+				"esbuild-linux-arm": "0.15.5",
+				"esbuild-linux-arm64": "0.15.5",
+				"esbuild-linux-mips64le": "0.15.5",
+				"esbuild-linux-ppc64le": "0.15.5",
+				"esbuild-linux-riscv64": "0.15.5",
+				"esbuild-linux-s390x": "0.15.5",
+				"esbuild-netbsd-64": "0.15.5",
+				"esbuild-openbsd-64": "0.15.5",
+				"esbuild-sunos-64": "0.15.5",
+				"esbuild-windows-32": "0.15.5",
+				"esbuild-windows-64": "0.15.5",
+				"esbuild-windows-arm64": "0.15.5"
 			}
 		},
 		"node_modules/esbuild-android-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.53.tgz",
-			"integrity": "sha512-fIL93sOTnEU+NrTAVMIKiAw0YH22HWCAgg4N4Z6zov2t0kY9RAJ50zY9ZMCQ+RT6bnOfDt8gCTnt/RaSNA2yRA==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.5.tgz",
+			"integrity": "sha512-dYPPkiGNskvZqmIK29OPxolyY3tp+c47+Fsc2WYSOVjEPWNCHNyqhtFqQadcXMJDQt8eN0NMDukbyQgFcHquXg==",
 			"cpu": [
 				"x64"
 			],
@@ -2819,9 +2832,9 @@
 			}
 		},
 		"node_modules/esbuild-android-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.53.tgz",
-			"integrity": "sha512-PC7KaF1v0h/nWpvlU1UMN7dzB54cBH8qSsm7S9mkwFA1BXpaEOufCg8hdoEI1jep0KeO/rjZVWrsH8+q28T77A==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.5.tgz",
+			"integrity": "sha512-YyEkaQl08ze3cBzI/4Cm1S+rVh8HMOpCdq8B78JLbNFHhzi4NixVN93xDrHZLztlocEYqi45rHHCgA8kZFidFg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2835,9 +2848,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.53.tgz",
-			"integrity": "sha512-gE7P5wlnkX4d4PKvLBUgmhZXvL7lzGRLri17/+CmmCzfncIgq8lOBvxGMiQ4xazplhxq+72TEohyFMZLFxuWvg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.5.tgz",
+			"integrity": "sha512-Cr0iIqnWKx3ZTvDUAzG0H/u9dWjLE4c2gTtRLz4pqOBGjfjqdcZSfAObFzKTInLLSmD0ZV1I/mshhPoYSBMMCQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2851,9 +2864,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.53.tgz",
-			"integrity": "sha512-otJwDU3hnI15Q98PX4MJbknSZ/WSR1I45il7gcxcECXzfN4Mrpft5hBDHXNRnCh+5858uPXBXA1Vaz2jVWLaIA==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.5.tgz",
+			"integrity": "sha512-WIfQkocGtFrz7vCu44ypY5YmiFXpsxvz2xqwe688jFfSVCnUsCn2qkEVDo7gT8EpsLOz1J/OmqjExePL1dr1Kg==",
 			"cpu": [
 				"arm64"
 			],
@@ -2867,9 +2880,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.53.tgz",
-			"integrity": "sha512-WkdJa8iyrGHyKiPF4lk0MiOF87Q2SkE+i+8D4Cazq3/iqmGPJ6u49je300MFi5I2eUsQCkaOWhpCVQMTKGww2w==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.5.tgz",
+			"integrity": "sha512-M5/EfzV2RsMd/wqwR18CELcenZ8+fFxQAAEO7TJKDmP3knhWSbD72ILzrXFMMwshlPAS1ShCZ90jsxkm+8FlaA==",
 			"cpu": [
 				"x64"
 			],
@@ -2883,9 +2896,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.53.tgz",
-			"integrity": "sha512-9T7WwCuV30NAx0SyQpw8edbKvbKELnnm1FHg7gbSYaatH+c8WJW10g/OdM7JYnv7qkimw2ZTtSA+NokOLd2ydQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.5.tgz",
+			"integrity": "sha512-2JQQ5Qs9J0440F/n/aUBNvY6lTo4XP/4lt1TwDfHuo0DY3w5++anw+jTjfouLzbJmFFiwmX7SmUhMnysocx96w==",
 			"cpu": [
 				"arm64"
 			],
@@ -2899,9 +2912,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-32": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.53.tgz",
-			"integrity": "sha512-VGanLBg5en2LfGDgLEUxQko2lqsOS7MTEWUi8x91YmsHNyzJVT/WApbFFx3MQGhkf+XdimVhpyo5/G0PBY91zg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.5.tgz",
+			"integrity": "sha512-gO9vNnIN0FTUGjvTFucIXtBSr1Woymmx/aHQtuU+2OllGU6YFLs99960UD4Dib1kFovVgs59MTXwpFdVoSMZoQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -2915,9 +2928,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.53.tgz",
-			"integrity": "sha512-pP/FA55j/fzAV7N9DF31meAyjOH6Bjuo3aSKPh26+RW85ZEtbJv9nhoxmGTd9FOqjx59Tc1ZbrJabuiXlMwuZQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.5.tgz",
+			"integrity": "sha512-ne0GFdNLsm4veXbTnYAWjbx3shpNKZJUd6XpNbKNUZaNllDZfYQt0/zRqOg0sc7O8GQ+PjSMv9IpIEULXVTVmg==",
 			"cpu": [
 				"x64"
 			],
@@ -2931,9 +2944,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.53.tgz",
-			"integrity": "sha512-/u81NGAVZMopbmzd21Nu/wvnKQK3pT4CrvQ8BTje1STXcQAGnfyKgQlj3m0j2BzYbvQxSy+TMck4TNV2onvoPA==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.5.tgz",
+			"integrity": "sha512-wvAoHEN+gJ/22gnvhZnS/+2H14HyAxM07m59RSLn3iXrQsdS518jnEWRBnJz3fR6BJa+VUTo0NxYjGaNt7RA7Q==",
 			"cpu": [
 				"arm"
 			],
@@ -2947,9 +2960,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.53.tgz",
-			"integrity": "sha512-GDmWITT+PMsjCA6/lByYk7NyFssW4Q6in32iPkpjZ/ytSyH+xeEx8q7HG3AhWH6heemEYEWpTll/eui3jwlSnw==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.5.tgz",
+			"integrity": "sha512-7EgFyP2zjO065XTfdCxiXVEk+f83RQ1JsryN1X/VSX2li9rnHAt2swRbpoz5Vlrl6qjHrCmq5b6yxD13z6RheA==",
 			"cpu": [
 				"arm64"
 			],
@@ -2963,9 +2976,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.53.tgz",
-			"integrity": "sha512-d6/XHIQW714gSSp6tOOX2UscedVobELvQlPMkInhx1NPz4ThZI9uNLQ4qQJHGBGKGfu+rtJsxM4NVHLhnNRdWQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.5.tgz",
+			"integrity": "sha512-KdnSkHxWrJ6Y40ABu+ipTZeRhFtc8dowGyFsZY5prsmMSr1ZTG9zQawguN4/tunJ0wy3+kD54GaGwdcpwWAvZQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -2979,9 +2992,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.53.tgz",
-			"integrity": "sha512-ndnJmniKPCB52m+r6BtHHLAOXw+xBCWIxNnedbIpuREOcbSU/AlyM/2dA3BmUQhsHdb4w3amD5U2s91TJ3MzzA==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.5.tgz",
+			"integrity": "sha512-QdRHGeZ2ykl5P0KRmfGBZIHmqcwIsUKWmmpZTOq573jRWwmpfRmS7xOhmDHBj9pxv+6qRMH8tLr2fe+ZKQvCYw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -2995,9 +3008,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.53.tgz",
-			"integrity": "sha512-yG2sVH+QSix6ct4lIzJj329iJF3MhloLE6/vKMQAAd26UVPVkhMFqFopY+9kCgYsdeWvXdPgmyOuKa48Y7+/EQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.5.tgz",
+			"integrity": "sha512-p+WE6RX+jNILsf+exR29DwgV6B73khEQV0qWUbzxaycxawZ8NE0wA6HnnTxbiw5f4Gx9sJDUBemh9v49lKOORA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3011,9 +3024,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-s390x": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.53.tgz",
-			"integrity": "sha512-OCJlgdkB+XPYndHmw6uZT7jcYgzmx9K+28PVdOa/eLjdoYkeAFvH5hTwX4AXGLZLH09tpl4bVsEtvuyUldaNCg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.5.tgz",
+			"integrity": "sha512-J2ngOB4cNzmqLHh6TYMM/ips8aoZIuzxJnDdWutBw5482jGXiOzsPoEF4j2WJ2mGnm7FBCO4StGcwzOgic70JQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -3027,9 +3040,9 @@
 			}
 		},
 		"node_modules/esbuild-netbsd-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.53.tgz",
-			"integrity": "sha512-gp2SB+Efc7MhMdWV2+pmIs/Ja/Mi5rjw+wlDmmbIn68VGXBleNgiEZG+eV2SRS0kJEUyHNedDtwRIMzaohWedQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.5.tgz",
+			"integrity": "sha512-MmKUYGDizYjFia0Rwt8oOgmiFH7zaYlsoQ3tIOfPxOqLssAsEgG0MUdRDm5lliqjiuoog8LyDu9srQk5YwWF3w==",
 			"cpu": [
 				"x64"
 			],
@@ -3043,9 +3056,9 @@
 			}
 		},
 		"node_modules/esbuild-openbsd-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.53.tgz",
-			"integrity": "sha512-eKQ30ZWe+WTZmteDYg8S+YjHV5s4iTxeSGhJKJajFfQx9TLZJvsJX0/paqwP51GicOUruFpSUAs2NCc0a4ivQQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.5.tgz",
+			"integrity": "sha512-2mMFfkLk3oPWfopA9Plj4hyhqHNuGyp5KQyTT9Rc8hFd8wAn5ZrbJg+gNcLMo2yzf8Uiu0RT6G9B15YN9WQyMA==",
 			"cpu": [
 				"x64"
 			],
@@ -3059,9 +3072,9 @@
 			}
 		},
 		"node_modules/esbuild-sunos-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.53.tgz",
-			"integrity": "sha512-OWLpS7a2FrIRukQqcgQqR1XKn0jSJoOdT+RlhAxUoEQM/IpytS3FXzCJM6xjUYtpO5GMY0EdZJp+ur2pYdm39g==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.5.tgz",
+			"integrity": "sha512-2sIzhMUfLNoD+rdmV6AacilCHSxZIoGAU2oT7XmJ0lXcZWnCvCtObvO6D4puxX9YRE97GodciRGDLBaiC6x1SA==",
 			"cpu": [
 				"x64"
 			],
@@ -3075,9 +3088,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-32": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.53.tgz",
-			"integrity": "sha512-m14XyWQP5rwGW0tbEfp95U6A0wY0DYPInWBB7D69FAXUpBpBObRoGTKRv36lf2RWOdE4YO3TNvj37zhXjVL5xg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.5.tgz",
+			"integrity": "sha512-e+duNED9UBop7Vnlap6XKedA/53lIi12xv2ebeNS4gFmu7aKyTrok7DPIZyU5w/ftHD4MUDs5PJUkQPP9xJRzg==",
 			"cpu": [
 				"ia32"
 			],
@@ -3091,9 +3104,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.53.tgz",
-			"integrity": "sha512-s9skQFF0I7zqnQ2K8S1xdLSfZFsPLuOGmSx57h2btSEswv0N0YodYvqLcJMrNMXh6EynOmWD7rz+0rWWbFpIHQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.5.tgz",
+			"integrity": "sha512-v+PjvNtSASHOjPDMIai9Yi+aP+Vwox+3WVdg2JB8N9aivJ7lyhp4NVU+J0MV2OkWFPnVO8AE/7xH+72ibUUEnw==",
 			"cpu": [
 				"x64"
 			],
@@ -3107,9 +3120,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.53.tgz",
-			"integrity": "sha512-E+5Gvb+ZWts+00T9II6wp2L3KG2r3iGxByqd/a1RmLmYWVsSVUjkvIxZuJ3hYTIbhLkH5PRwpldGTKYqVz0nzQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.5.tgz",
+			"integrity": "sha512-Yz8w/D8CUPYstvVQujByu6mlf48lKmXkq6bkeSZZxTA626efQOJb26aDGLzmFWx6eg/FwrXgt6SZs9V8Pwy/aA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3149,9 +3162,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-			"integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
+			"integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint/eslintrc": "^1.3.0",
@@ -3648,9 +3661,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-			"integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
 		"node_modules/for-each": {
@@ -4063,15 +4076,6 @@
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
-		},
-		"node_modules/graphql": {
-			"version": "16.5.0",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-			"integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
-			"dev": true,
-			"engines": {
-				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
-			}
 		},
 		"node_modules/handlebars": {
 			"version": "4.7.7",
@@ -6040,11 +6044,383 @@
 				}
 			}
 		},
+		"node_modules/mkdist/node_modules/@esbuild/linux-loong64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+			"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/mkdist/node_modules/defu": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/defu/-/defu-6.0.0.tgz",
-			"integrity": "sha512-t2MZGLf1V2rV4VBZbWIaXKdX/mUcYW0n2znQZoADBkGGxYL8EWqCuCZBmJPJ/Yy9fofJkyuuSuo5GSwo0XdEgw==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.0.tgz",
+			"integrity": "sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==",
 			"dev": true
+		},
+		"node_modules/mkdist/node_modules/esbuild": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+			"integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/linux-loong64": "0.14.54",
+				"esbuild-android-64": "0.14.54",
+				"esbuild-android-arm64": "0.14.54",
+				"esbuild-darwin-64": "0.14.54",
+				"esbuild-darwin-arm64": "0.14.54",
+				"esbuild-freebsd-64": "0.14.54",
+				"esbuild-freebsd-arm64": "0.14.54",
+				"esbuild-linux-32": "0.14.54",
+				"esbuild-linux-64": "0.14.54",
+				"esbuild-linux-arm": "0.14.54",
+				"esbuild-linux-arm64": "0.14.54",
+				"esbuild-linux-mips64le": "0.14.54",
+				"esbuild-linux-ppc64le": "0.14.54",
+				"esbuild-linux-riscv64": "0.14.54",
+				"esbuild-linux-s390x": "0.14.54",
+				"esbuild-netbsd-64": "0.14.54",
+				"esbuild-openbsd-64": "0.14.54",
+				"esbuild-sunos-64": "0.14.54",
+				"esbuild-windows-32": "0.14.54",
+				"esbuild-windows-64": "0.14.54",
+				"esbuild-windows-arm64": "0.14.54"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-android-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+			"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-android-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+			"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-darwin-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+			"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-darwin-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+			"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-freebsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+			"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-freebsd-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+			"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-linux-32": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+			"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-linux-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+			"integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-linux-arm": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+			"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-linux-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+			"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-linux-mips64le": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+			"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-linux-ppc64le": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+			"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-linux-riscv64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+			"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-linux-s390x": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+			"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-netbsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+			"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-openbsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+			"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-sunos-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+			"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-windows-32": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+			"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-windows-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+			"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/mkdist/node_modules/esbuild-windows-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+			"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/modify-values": {
 			"version": "1.0.1",
@@ -6071,9 +6447,9 @@
 			"dev": true
 		},
 		"node_modules/msw": {
-			"version": "0.44.2",
-			"resolved": "https://registry.npmjs.org/msw/-/msw-0.44.2.tgz",
-			"integrity": "sha512-u8wjzzcMWouoZtuIShCwx4M3wFF5sBAV1f8K4a0WX8kiihFjzl89IKE1VYmTclLyMIwpOq8qQ1HTpuh2BFX/3A==",
+			"version": "0.45.0",
+			"resolved": "https://registry.npmjs.org/msw/-/msw-0.45.0.tgz",
+			"integrity": "sha512-aZgYsSJWYLHj5wZs/g640GP5AK6gfHC6dKTED8bforKZx10IJ+b0z7Y+0infEKD4gNT3orj7tiUZe4pxgpY0SQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -6085,7 +6461,6 @@
 				"chalk": "4.1.1",
 				"chokidar": "^3.4.2",
 				"cookie": "^0.4.2",
-				"graphql": "^16.3.0",
 				"headers-polyfill": "^3.0.4",
 				"inquirer": "^8.2.0",
 				"is-node-process": "^1.0.1",
@@ -6109,9 +6484,13 @@
 				"url": "https://opencollective.com/mswjs"
 			},
 			"peerDependencies": {
+				"graphql": "^15.0.0 || ^16.0.0",
 				"typescript": ">= 4.2.x <= 4.7.x"
 			},
 			"peerDependenciesMeta": {
+				"graphql": {
+					"optional": true
+				},
 				"typescript": {
 					"optional": true
 				}
@@ -6519,14 +6898,14 @@
 			}
 		},
 		"node_modules/object.assign": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3",
-				"has-symbols": "^1.0.1",
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			},
 			"engines": {
@@ -6891,9 +7270,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+			"version": "8.4.16",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+			"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -7337,9 +7716,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.77.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-			"integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -7594,9 +7973,9 @@
 			}
 		},
 		"node_modules/size-limit": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.0.0.tgz",
-			"integrity": "sha512-344dzCZZiTz+N0WS801SNG/qd8MCa6dzJhsj8gLQg4JlmddwUdi/Ol0HfliEVL7jgtOz8fNgDeB2+14xwalvVA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.0.1.tgz",
+			"integrity": "sha512-VHrozqkQTYfcv1OlZIRIL0x6f+xhZ3TT+RTXC5AvKn/yA+3PIWERrKWqHMJPD7G/Vi0SuBtWAn3IvCGx2/UB1g==",
 			"dev": true,
 			"dependencies": {
 				"bytes-iec": "^3.1.1",
@@ -7744,9 +8123,9 @@
 			}
 		},
 		"node_modules/spdx-license-ids": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
 			"dev": true
 		},
 		"node_modules/split": {
@@ -8102,9 +8481,9 @@
 			}
 		},
 		"node_modules/tinyspy": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.0.tgz",
-			"integrity": "sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz",
+			"integrity": "sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==",
 			"dev": true,
 			"engines": {
 				"node": ">=14.0.0"
@@ -8247,9 +8626,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.16.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
-			"integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+			"integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -8437,15 +8816,15 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
-			"integrity": "sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
+			"integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.14.47",
-				"postcss": "^8.4.14",
+				"postcss": "^8.4.16",
 				"resolve": "^1.22.1",
-				"rollup": "^2.75.6"
+				"rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -8477,6 +8856,378 @@
 				}
 			}
 		},
+		"node_modules/vite/node_modules/@esbuild/linux-loong64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+			"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+			"integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"optionalDependencies": {
+				"@esbuild/linux-loong64": "0.14.54",
+				"esbuild-android-64": "0.14.54",
+				"esbuild-android-arm64": "0.14.54",
+				"esbuild-darwin-64": "0.14.54",
+				"esbuild-darwin-arm64": "0.14.54",
+				"esbuild-freebsd-64": "0.14.54",
+				"esbuild-freebsd-arm64": "0.14.54",
+				"esbuild-linux-32": "0.14.54",
+				"esbuild-linux-64": "0.14.54",
+				"esbuild-linux-arm": "0.14.54",
+				"esbuild-linux-arm64": "0.14.54",
+				"esbuild-linux-mips64le": "0.14.54",
+				"esbuild-linux-ppc64le": "0.14.54",
+				"esbuild-linux-riscv64": "0.14.54",
+				"esbuild-linux-s390x": "0.14.54",
+				"esbuild-netbsd-64": "0.14.54",
+				"esbuild-openbsd-64": "0.14.54",
+				"esbuild-sunos-64": "0.14.54",
+				"esbuild-windows-32": "0.14.54",
+				"esbuild-windows-64": "0.14.54",
+				"esbuild-windows-arm64": "0.14.54"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-android-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+			"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-android-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+			"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-darwin-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+			"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-darwin-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+			"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-freebsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+			"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-freebsd-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+			"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-32": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+			"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+			"integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-arm": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+			"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+			"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-mips64le": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+			"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-ppc64le": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+			"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-riscv64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+			"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-linux-s390x": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+			"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-netbsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+			"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-openbsd-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+			"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-sunos-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+			"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-windows-32": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+			"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-windows-64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+			"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/vite/node_modules/esbuild-windows-arm64": {
+			"version": "0.14.54",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+			"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/vite/node_modules/resolve": {
 			"version": "1.22.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -8494,20 +9245,35 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/vite/node_modules/rollup": {
+			"version": "2.77.3",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+			"integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+			"dev": true,
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
 		"node_modules/vitest": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.21.0.tgz",
-			"integrity": "sha512-+BQB2swk4wQdw5loOoL8esIYh/1ifAliuwj2HWHNE2F8SAl/jF7/aoCJBoXGSf/Ws19k3pH4NrWeVtcSwM0j2w==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.22.1.tgz",
+			"integrity": "sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==",
 			"dev": true,
 			"dependencies": {
-				"@types/chai": "^4.3.1",
+				"@types/chai": "^4.3.3",
 				"@types/chai-subset": "^1.3.3",
 				"@types/node": "*",
 				"chai": "^4.3.6",
 				"debug": "^4.3.4",
 				"local-pkg": "^0.4.2",
 				"tinypool": "^0.2.4",
-				"tinyspy": "^1.0.0",
+				"tinyspy": "^1.0.2",
 				"vite": "^2.9.12 || ^3.0.0-0"
 			},
 			"bin": {
@@ -8523,7 +9289,6 @@
 				"@edge-runtime/vm": "*",
 				"@vitest/browser": "*",
 				"@vitest/ui": "*",
-				"c8": "*",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},
@@ -8535,9 +9300,6 @@
 					"optional": true
 				},
 				"@vitest/ui": {
-					"optional": true
-				},
-				"c8": {
 					"optional": true
 				},
 				"happy-dom": {
@@ -8786,27 +9548,27 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.18.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.8.tgz",
-			"integrity": "sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
+			"integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
-			"integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
+			"integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
 			"dev": true,
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.18.13",
 				"@babel/helper-compilation-targets": "^7.18.9",
 				"@babel/helper-module-transforms": "^7.18.9",
 				"@babel/helpers": "^7.18.9",
-				"@babel/parser": "^7.18.10",
+				"@babel/parser": "^7.18.13",
 				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.10",
-				"@babel/types": "^7.18.10",
+				"@babel/traverse": "^7.18.13",
+				"@babel/types": "^7.18.13",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -8823,12 +9585,12 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.18.12",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
-			"integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
+			"integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.18.10",
+				"@babel/types": "^7.18.13",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"jsesc": "^2.5.1"
 			},
@@ -9033,9 +9795,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz",
-			"integrity": "sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
+			"integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
 			"dev": true
 		},
 		"@babel/template": {
@@ -9050,19 +9812,19 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.18.11",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz",
-			"integrity": "sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
+			"integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.10",
+				"@babel/generator": "^7.18.13",
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-function-name": "^7.18.9",
 				"@babel/helper-hoist-variables": "^7.18.6",
 				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.11",
-				"@babel/types": "^7.18.10",
+				"@babel/parser": "^7.18.13",
+				"@babel/types": "^7.18.13",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -9076,9 +9838,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.10.tgz",
-			"integrity": "sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==",
+			"version": "7.18.13",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
+			"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-string-parser": "^7.18.10",
@@ -9093,9 +9855,9 @@
 			"dev": true
 		},
 		"@esbuild/linux-loong64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.53.tgz",
-			"integrity": "sha512-W2dAL6Bnyn4xa/QRSU3ilIK4EzD5wgYXKXJiS1HDF5vU3675qc2bvFyLwbUcdmssDveyndy7FbitrCoiV/eMLg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.5.tgz",
+			"integrity": "sha512-UHkDFCfSGTuXq08oQltXxSZmH1TXyWsL+4QhZDWvvLl6mEJQqk3u7/wq1LjhrrAXYIllaTtRSzUXl4Olkf2J8A==",
 			"dev": true,
 			"optional": true
 		},
@@ -9257,9 +10019,9 @@
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
-			"integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+			"version": "0.3.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+			"integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -9295,9 +10057,9 @@
 			}
 		},
 		"@mswjs/interceptors": {
-			"version": "0.17.3",
-			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.3.tgz",
-			"integrity": "sha512-jBRFPeHBPqKv3od8KPjmrvt4b/+e1DorizFDYJ8NQCrjFT9YGnxA8ojGi0MIo64x/JgdjYkhP8bG9EY4BGPoqg==",
+			"version": "0.17.4",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.4.tgz",
+			"integrity": "sha512-8oKWrOQ1P0Wj0kf3ak8WETuymknw2Tl2s1op8OzZctpNF3zSJSdEbcQs0pm347mwsM+95V6POBMv3W4812pEeg==",
 			"dev": true,
 			"requires": {
 				"@open-draft/until": "^1.0.3",
@@ -9373,9 +10135,9 @@
 			}
 		},
 		"@prismicio/types": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.1.tgz",
-			"integrity": "sha512-FIj6trxFNlpO7WLYgV6UsURK6tAIXJPoFY9MuNW3eDcdw3he0C/aCRi57ApFiaIyroUSIajPNtWyMYzItD6wSg=="
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.2.3.tgz",
+			"integrity": "sha512-mHsZ9ora8He6PAn+Q/0MCVdlfc0Xv8rSEYJyfwywDApuvssGvgUbeHE6XTqPhK2dJwb0mAkJzCpZiQJRt9+bvw=="
 		},
 		"@rollup/plugin-alias": {
 			"version": "3.1.9",
@@ -9454,38 +10216,38 @@
 			}
 		},
 		"@size-limit/esbuild": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@size-limit/esbuild/-/esbuild-8.0.0.tgz",
-			"integrity": "sha512-du3gGKAzeh8fKEbqG0PcHKyyilpHTC+z/e6r0a82G+9KMCQd2PBHfOrTyN+of8u6EZXkrp0zdwgr84nKLp1nPg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@size-limit/esbuild/-/esbuild-8.0.1.tgz",
+			"integrity": "sha512-EnfRweoQc4P91G45sPfzAWMVPibK5SEV6sUWC46DcGlT9xrYeCQYtInbsny1/lSorC/sfJKN84aGm4A+q6SgOw==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.14.51",
+				"esbuild": "^0.15.1",
 				"nanoid": "^3.3.4"
 			}
 		},
 		"@size-limit/file": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@size-limit/file/-/file-8.0.0.tgz",
-			"integrity": "sha512-xd4bBk/YyezsMQfpi2V3/blodCuPNVF5UwMd4L9LxBvon0PK4C1+3zBXxZpvN7AcMvPbJ8RUMS+iHpD4KcwaOg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@size-limit/file/-/file-8.0.1.tgz",
+			"integrity": "sha512-kwgc5UJQIz5qbRow3atSiW2K7vEIIw4DelT4WLn09cOwcJgWs82Imgz2UqVivHJmCisn/ltPjT4qmxaDfjFflw==",
 			"dev": true,
 			"requires": {
 				"semver": "7.3.7"
 			}
 		},
 		"@size-limit/preset-small-lib": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@size-limit/preset-small-lib/-/preset-small-lib-8.0.0.tgz",
-			"integrity": "sha512-6Q2fJFuPalvANQIoxYAmQLGk1Rxerw/qtqpEi1dhF9czfWxtYxKwlVQgsE/d0j5eum/N7iJxioDeKZQJjzKPrQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@size-limit/preset-small-lib/-/preset-small-lib-8.0.1.tgz",
+			"integrity": "sha512-EV+UXGZJU9kiT8R4N9dxjRAJ37tzjuP+e2DfpRtv7cx1ErFiB6k//wEhw9nLmJMWWhfvcVEvJYyKm3+i0pbWUQ==",
 			"dev": true,
 			"requires": {
-				"@size-limit/esbuild": "8.0.0",
-				"@size-limit/file": "8.0.0"
+				"@size-limit/esbuild": "8.0.1",
+				"@size-limit/file": "8.0.1"
 			}
 		},
 		"@types/chai": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
-			"integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
+			"integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
 			"dev": true
 		},
 		"@types/chai-subset": {
@@ -9574,9 +10336,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.6.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.4.tgz",
-			"integrity": "sha512-I4BD3L+6AWiUobfxZ49DlU43gtI+FTHSv9pE2Zekg6KjMpre4ByusaljW3vYSLJrvQ1ck1hUaeVu8HVlY3vzHg==",
+			"version": "18.7.10",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.10.tgz",
+			"integrity": "sha512-SST7B//wF7xlGoLo1IEVB0cQ4e7BgXlDk5IaPgb5s0DlYLjb4if07h8+0zbQIvahfPNXs6e7zyT0EH1MqaS+5g==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -9625,14 +10387,14 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.32.0.tgz",
-			"integrity": "sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.34.0.tgz",
+			"integrity": "sha512-eRfPPcasO39iwjlUAMtjeueRGuIrW3TQ9WseIDl7i5UWuFbf83yYaU7YPs4j8+4CxUMIsj1k+4kV+E+G+6ypDQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/type-utils": "5.32.0",
-				"@typescript-eslint/utils": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.34.0",
+				"@typescript-eslint/type-utils": "5.34.0",
+				"@typescript-eslint/utils": "5.34.0",
 				"debug": "^4.3.4",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.2.0",
@@ -9642,52 +10404,52 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.32.0.tgz",
-			"integrity": "sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.34.0.tgz",
+			"integrity": "sha512-SZ3NEnK4usd2CXkoV3jPa/vo1mWX1fqRyIVUQZR4As1vyp4fneknBNJj+OFtV8WAVgGf+rOHMSqQbs2Qn3nFZQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/typescript-estree": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.34.0",
+				"@typescript-eslint/types": "5.34.0",
+				"@typescript-eslint/typescript-estree": "5.34.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.32.0.tgz",
-			"integrity": "sha512-KyAE+tUON0D7tNz92p1uetRqVJiiAkeluvwvZOqBmW9z2XApmk5WSMV9FrzOroAcVxJZB3GfUwVKr98Dr/OjOg==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.34.0.tgz",
+			"integrity": "sha512-HNvASMQlah5RsBW6L6c7IJ0vsm+8Sope/wu5sEAf7joJYWNb1LDbJipzmdhdUOnfrDFE6LR1j57x1EYVxrY4ow==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/visitor-keys": "5.32.0"
+				"@typescript-eslint/types": "5.34.0",
+				"@typescript-eslint/visitor-keys": "5.34.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.32.0.tgz",
-			"integrity": "sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.34.0.tgz",
+			"integrity": "sha512-Pxlno9bjsQ7hs1pdWRUv9aJijGYPYsHpwMeCQ/Inavhym3/XaKt1ZKAA8FIw4odTBfowBdZJDMxf2aavyMDkLg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.32.0",
+				"@typescript-eslint/utils": "5.34.0",
 				"debug": "^4.3.4",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.32.0.tgz",
-			"integrity": "sha512-EBUKs68DOcT/EjGfzywp+f8wG9Zw6gj6BjWu7KV/IYllqKJFPlZlLSYw/PTvVyiRw50t6wVbgv4p9uE2h6sZrQ==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.34.0.tgz",
+			"integrity": "sha512-49fm3xbbUPuzBIOcy2CDpYWqy/X7VBkxVN+DC21e0zIm3+61Z0NZi6J9mqPmSW1BDVk9FIOvuCFyUPjXz93sjA==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.32.0.tgz",
-			"integrity": "sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.34.0.tgz",
+			"integrity": "sha512-mXHAqapJJDVzxauEkfJI96j3D10sd567LlqroyCeJaHnu42sDbjxotGb3XFtGPYKPD9IyLjhsoULML1oI3M86A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/visitor-keys": "5.32.0",
+				"@typescript-eslint/types": "5.34.0",
+				"@typescript-eslint/visitor-keys": "5.34.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -9696,27 +10458,37 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.32.0.tgz",
-			"integrity": "sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.34.0.tgz",
+			"integrity": "sha512-kWRYybU4Rn++7lm9yu8pbuydRyQsHRoBDIo11k7eqBWTldN4xUdVUMCsHBiE7aoEkFzrUEaZy3iH477vr4xHAQ==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.32.0",
-				"@typescript-eslint/types": "5.32.0",
-				"@typescript-eslint/typescript-estree": "5.32.0",
+				"@typescript-eslint/scope-manager": "5.34.0",
+				"@typescript-eslint/types": "5.34.0",
+				"@typescript-eslint/typescript-estree": "5.34.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.32.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.32.0.tgz",
-			"integrity": "sha512-S54xOHZgfThiZ38/ZGTgB2rqx51CMJ5MCfVT2IplK4Q7hgzGfe0nLzLCcenDnc/cSjP568hdeKfeDcBgqNHD/g==",
+			"version": "5.34.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.34.0.tgz",
+			"integrity": "sha512-O1moYjOSrab0a2fUvFpsJe0QHtvTC+cR+ovYpgKrAVXzqQyc74mv76TgY6z+aEtjQE2vgZux3CQVtGryqdcOAw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.32.0",
+				"@typescript-eslint/types": "5.34.0",
 				"eslint-visitor-keys": "^3.3.0"
+			}
+		},
+		"@vitest/coverage-c8": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.22.1.tgz",
+			"integrity": "sha512-KOOYpO7EGpaF+nD8GD+Y05D0JtZp12NUu6DdLXvBPqSOPo2HkZ7KNBtfR0rb6gOy3NLtGiWTYTzCwhajgb2HlA==",
+			"dev": true,
+			"requires": {
+				"c8": "^7.12.0",
+				"vitest": "0.22.1"
 			}
 		},
 		"@xmldom/xmldom": {
@@ -10051,9 +10823,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001374",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001374.tgz",
-			"integrity": "sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==",
+			"version": "1.0.30001381",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001381.tgz",
+			"integrity": "sha512-fEnkDOKpvp6qc+olg7+NzE1SqyfiyKf4uci7fAU38M3zxs0YOyKOxW/nMZ2l9sJbt7KZHcDIxUnbI0Iime7V4w==",
 			"dev": true
 		},
 		"capital-case": {
@@ -10746,9 +11518,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.4.211",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.211.tgz",
-			"integrity": "sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==",
+			"version": "1.4.225",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.225.tgz",
+			"integrity": "sha512-ICHvGaCIQR3P88uK8aRtx8gmejbVJyC6bB4LEC3anzBrIzdzC7aiZHY4iFfXhN4st6I7lMO0x4sgBHf/7kBvRw==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -10815,171 +11587,171 @@
 			"dev": true
 		},
 		"esbuild": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.53.tgz",
-			"integrity": "sha512-ohO33pUBQ64q6mmheX1mZ8mIXj8ivQY/L4oVuAshr+aJI+zLl+amrp3EodrUNDNYVrKJXGPfIHFGhO8slGRjuw==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.5.tgz",
+			"integrity": "sha512-VSf6S1QVqvxfIsSKb3UKr3VhUCis7wgDbtF4Vd9z84UJr05/Sp2fRKmzC+CSPG/dNAPPJZ0BTBLTT1Fhd6N9Gg==",
 			"dev": true,
 			"requires": {
-				"@esbuild/linux-loong64": "0.14.53",
-				"esbuild-android-64": "0.14.53",
-				"esbuild-android-arm64": "0.14.53",
-				"esbuild-darwin-64": "0.14.53",
-				"esbuild-darwin-arm64": "0.14.53",
-				"esbuild-freebsd-64": "0.14.53",
-				"esbuild-freebsd-arm64": "0.14.53",
-				"esbuild-linux-32": "0.14.53",
-				"esbuild-linux-64": "0.14.53",
-				"esbuild-linux-arm": "0.14.53",
-				"esbuild-linux-arm64": "0.14.53",
-				"esbuild-linux-mips64le": "0.14.53",
-				"esbuild-linux-ppc64le": "0.14.53",
-				"esbuild-linux-riscv64": "0.14.53",
-				"esbuild-linux-s390x": "0.14.53",
-				"esbuild-netbsd-64": "0.14.53",
-				"esbuild-openbsd-64": "0.14.53",
-				"esbuild-sunos-64": "0.14.53",
-				"esbuild-windows-32": "0.14.53",
-				"esbuild-windows-64": "0.14.53",
-				"esbuild-windows-arm64": "0.14.53"
+				"@esbuild/linux-loong64": "0.15.5",
+				"esbuild-android-64": "0.15.5",
+				"esbuild-android-arm64": "0.15.5",
+				"esbuild-darwin-64": "0.15.5",
+				"esbuild-darwin-arm64": "0.15.5",
+				"esbuild-freebsd-64": "0.15.5",
+				"esbuild-freebsd-arm64": "0.15.5",
+				"esbuild-linux-32": "0.15.5",
+				"esbuild-linux-64": "0.15.5",
+				"esbuild-linux-arm": "0.15.5",
+				"esbuild-linux-arm64": "0.15.5",
+				"esbuild-linux-mips64le": "0.15.5",
+				"esbuild-linux-ppc64le": "0.15.5",
+				"esbuild-linux-riscv64": "0.15.5",
+				"esbuild-linux-s390x": "0.15.5",
+				"esbuild-netbsd-64": "0.15.5",
+				"esbuild-openbsd-64": "0.15.5",
+				"esbuild-sunos-64": "0.15.5",
+				"esbuild-windows-32": "0.15.5",
+				"esbuild-windows-64": "0.15.5",
+				"esbuild-windows-arm64": "0.15.5"
 			}
 		},
 		"esbuild-android-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.53.tgz",
-			"integrity": "sha512-fIL93sOTnEU+NrTAVMIKiAw0YH22HWCAgg4N4Z6zov2t0kY9RAJ50zY9ZMCQ+RT6bnOfDt8gCTnt/RaSNA2yRA==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.5.tgz",
+			"integrity": "sha512-dYPPkiGNskvZqmIK29OPxolyY3tp+c47+Fsc2WYSOVjEPWNCHNyqhtFqQadcXMJDQt8eN0NMDukbyQgFcHquXg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-android-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.53.tgz",
-			"integrity": "sha512-PC7KaF1v0h/nWpvlU1UMN7dzB54cBH8qSsm7S9mkwFA1BXpaEOufCg8hdoEI1jep0KeO/rjZVWrsH8+q28T77A==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.5.tgz",
+			"integrity": "sha512-YyEkaQl08ze3cBzI/4Cm1S+rVh8HMOpCdq8B78JLbNFHhzi4NixVN93xDrHZLztlocEYqi45rHHCgA8kZFidFg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.53.tgz",
-			"integrity": "sha512-gE7P5wlnkX4d4PKvLBUgmhZXvL7lzGRLri17/+CmmCzfncIgq8lOBvxGMiQ4xazplhxq+72TEohyFMZLFxuWvg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.5.tgz",
+			"integrity": "sha512-Cr0iIqnWKx3ZTvDUAzG0H/u9dWjLE4c2gTtRLz4pqOBGjfjqdcZSfAObFzKTInLLSmD0ZV1I/mshhPoYSBMMCQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.53.tgz",
-			"integrity": "sha512-otJwDU3hnI15Q98PX4MJbknSZ/WSR1I45il7gcxcECXzfN4Mrpft5hBDHXNRnCh+5858uPXBXA1Vaz2jVWLaIA==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.5.tgz",
+			"integrity": "sha512-WIfQkocGtFrz7vCu44ypY5YmiFXpsxvz2xqwe688jFfSVCnUsCn2qkEVDo7gT8EpsLOz1J/OmqjExePL1dr1Kg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.53.tgz",
-			"integrity": "sha512-WkdJa8iyrGHyKiPF4lk0MiOF87Q2SkE+i+8D4Cazq3/iqmGPJ6u49je300MFi5I2eUsQCkaOWhpCVQMTKGww2w==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.5.tgz",
+			"integrity": "sha512-M5/EfzV2RsMd/wqwR18CELcenZ8+fFxQAAEO7TJKDmP3knhWSbD72ILzrXFMMwshlPAS1ShCZ90jsxkm+8FlaA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.53.tgz",
-			"integrity": "sha512-9T7WwCuV30NAx0SyQpw8edbKvbKELnnm1FHg7gbSYaatH+c8WJW10g/OdM7JYnv7qkimw2ZTtSA+NokOLd2ydQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.5.tgz",
+			"integrity": "sha512-2JQQ5Qs9J0440F/n/aUBNvY6lTo4XP/4lt1TwDfHuo0DY3w5++anw+jTjfouLzbJmFFiwmX7SmUhMnysocx96w==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-32": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.53.tgz",
-			"integrity": "sha512-VGanLBg5en2LfGDgLEUxQko2lqsOS7MTEWUi8x91YmsHNyzJVT/WApbFFx3MQGhkf+XdimVhpyo5/G0PBY91zg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.5.tgz",
+			"integrity": "sha512-gO9vNnIN0FTUGjvTFucIXtBSr1Woymmx/aHQtuU+2OllGU6YFLs99960UD4Dib1kFovVgs59MTXwpFdVoSMZoQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.53.tgz",
-			"integrity": "sha512-pP/FA55j/fzAV7N9DF31meAyjOH6Bjuo3aSKPh26+RW85ZEtbJv9nhoxmGTd9FOqjx59Tc1ZbrJabuiXlMwuZQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.5.tgz",
+			"integrity": "sha512-ne0GFdNLsm4veXbTnYAWjbx3shpNKZJUd6XpNbKNUZaNllDZfYQt0/zRqOg0sc7O8GQ+PjSMv9IpIEULXVTVmg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.53.tgz",
-			"integrity": "sha512-/u81NGAVZMopbmzd21Nu/wvnKQK3pT4CrvQ8BTje1STXcQAGnfyKgQlj3m0j2BzYbvQxSy+TMck4TNV2onvoPA==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.5.tgz",
+			"integrity": "sha512-wvAoHEN+gJ/22gnvhZnS/+2H14HyAxM07m59RSLn3iXrQsdS518jnEWRBnJz3fR6BJa+VUTo0NxYjGaNt7RA7Q==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.53.tgz",
-			"integrity": "sha512-GDmWITT+PMsjCA6/lByYk7NyFssW4Q6in32iPkpjZ/ytSyH+xeEx8q7HG3AhWH6heemEYEWpTll/eui3jwlSnw==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.5.tgz",
+			"integrity": "sha512-7EgFyP2zjO065XTfdCxiXVEk+f83RQ1JsryN1X/VSX2li9rnHAt2swRbpoz5Vlrl6qjHrCmq5b6yxD13z6RheA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-mips64le": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.53.tgz",
-			"integrity": "sha512-d6/XHIQW714gSSp6tOOX2UscedVobELvQlPMkInhx1NPz4ThZI9uNLQ4qQJHGBGKGfu+rtJsxM4NVHLhnNRdWQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.5.tgz",
+			"integrity": "sha512-KdnSkHxWrJ6Y40ABu+ipTZeRhFtc8dowGyFsZY5prsmMSr1ZTG9zQawguN4/tunJ0wy3+kD54GaGwdcpwWAvZQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-ppc64le": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.53.tgz",
-			"integrity": "sha512-ndnJmniKPCB52m+r6BtHHLAOXw+xBCWIxNnedbIpuREOcbSU/AlyM/2dA3BmUQhsHdb4w3amD5U2s91TJ3MzzA==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.5.tgz",
+			"integrity": "sha512-QdRHGeZ2ykl5P0KRmfGBZIHmqcwIsUKWmmpZTOq573jRWwmpfRmS7xOhmDHBj9pxv+6qRMH8tLr2fe+ZKQvCYw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-riscv64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.53.tgz",
-			"integrity": "sha512-yG2sVH+QSix6ct4lIzJj329iJF3MhloLE6/vKMQAAd26UVPVkhMFqFopY+9kCgYsdeWvXdPgmyOuKa48Y7+/EQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.5.tgz",
+			"integrity": "sha512-p+WE6RX+jNILsf+exR29DwgV6B73khEQV0qWUbzxaycxawZ8NE0wA6HnnTxbiw5f4Gx9sJDUBemh9v49lKOORA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-s390x": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.53.tgz",
-			"integrity": "sha512-OCJlgdkB+XPYndHmw6uZT7jcYgzmx9K+28PVdOa/eLjdoYkeAFvH5hTwX4AXGLZLH09tpl4bVsEtvuyUldaNCg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.5.tgz",
+			"integrity": "sha512-J2ngOB4cNzmqLHh6TYMM/ips8aoZIuzxJnDdWutBw5482jGXiOzsPoEF4j2WJ2mGnm7FBCO4StGcwzOgic70JQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-netbsd-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.53.tgz",
-			"integrity": "sha512-gp2SB+Efc7MhMdWV2+pmIs/Ja/Mi5rjw+wlDmmbIn68VGXBleNgiEZG+eV2SRS0kJEUyHNedDtwRIMzaohWedQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.5.tgz",
+			"integrity": "sha512-MmKUYGDizYjFia0Rwt8oOgmiFH7zaYlsoQ3tIOfPxOqLssAsEgG0MUdRDm5lliqjiuoog8LyDu9srQk5YwWF3w==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-openbsd-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.53.tgz",
-			"integrity": "sha512-eKQ30ZWe+WTZmteDYg8S+YjHV5s4iTxeSGhJKJajFfQx9TLZJvsJX0/paqwP51GicOUruFpSUAs2NCc0a4ivQQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.5.tgz",
+			"integrity": "sha512-2mMFfkLk3oPWfopA9Plj4hyhqHNuGyp5KQyTT9Rc8hFd8wAn5ZrbJg+gNcLMo2yzf8Uiu0RT6G9B15YN9WQyMA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-sunos-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.53.tgz",
-			"integrity": "sha512-OWLpS7a2FrIRukQqcgQqR1XKn0jSJoOdT+RlhAxUoEQM/IpytS3FXzCJM6xjUYtpO5GMY0EdZJp+ur2pYdm39g==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.5.tgz",
+			"integrity": "sha512-2sIzhMUfLNoD+rdmV6AacilCHSxZIoGAU2oT7XmJ0lXcZWnCvCtObvO6D4puxX9YRE97GodciRGDLBaiC6x1SA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-32": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.53.tgz",
-			"integrity": "sha512-m14XyWQP5rwGW0tbEfp95U6A0wY0DYPInWBB7D69FAXUpBpBObRoGTKRv36lf2RWOdE4YO3TNvj37zhXjVL5xg==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.5.tgz",
+			"integrity": "sha512-e+duNED9UBop7Vnlap6XKedA/53lIi12xv2ebeNS4gFmu7aKyTrok7DPIZyU5w/ftHD4MUDs5PJUkQPP9xJRzg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.53.tgz",
-			"integrity": "sha512-s9skQFF0I7zqnQ2K8S1xdLSfZFsPLuOGmSx57h2btSEswv0N0YodYvqLcJMrNMXh6EynOmWD7rz+0rWWbFpIHQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.5.tgz",
+			"integrity": "sha512-v+PjvNtSASHOjPDMIai9Yi+aP+Vwox+3WVdg2JB8N9aivJ7lyhp4NVU+J0MV2OkWFPnVO8AE/7xH+72ibUUEnw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-arm64": {
-			"version": "0.14.53",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.53.tgz",
-			"integrity": "sha512-E+5Gvb+ZWts+00T9II6wp2L3KG2r3iGxByqd/a1RmLmYWVsSVUjkvIxZuJ3hYTIbhLkH5PRwpldGTKYqVz0nzQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.5.tgz",
+			"integrity": "sha512-Yz8w/D8CUPYstvVQujByu6mlf48lKmXkq6bkeSZZxTA626efQOJb26aDGLzmFWx6eg/FwrXgt6SZs9V8Pwy/aA==",
 			"dev": true,
 			"optional": true
 		},
@@ -11001,9 +11773,9 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.21.0.tgz",
-			"integrity": "sha512-/XJ1+Qurf1T9G2M5IHrsjp+xrGT73RZf23xA1z5wB1ZzzEAWSZKvRwhWxTFp1rvkvCfwcvAUNAP31bhKTTGfDA==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.22.0.tgz",
+			"integrity": "sha512-ci4t0sz6vSRKdmkOGmprBo6fmI4PrphDFMy5JEq/fNS0gQkJM3rLmrqcp8ipMcdobH3KtUP40KniAE9W19S4wA==",
 			"dev": true,
 			"requires": {
 				"@eslint/eslintrc": "^1.3.0",
@@ -11367,9 +12139,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.6.tgz",
-			"integrity": "sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==",
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true
 		},
 		"for-each": {
@@ -11671,12 +12443,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
-			"dev": true
-		},
-		"graphql": {
-			"version": "16.5.0",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.5.0.tgz",
-			"integrity": "sha512-qbHgh8Ix+j/qY+a/ZcJnFQ+j8ezakqPiHwPiZhV/3PgGlgf96QMBB5/f2rkiC9sgLoy/xvT6TSiaf2nTHJh5iA==",
 			"dev": true
 		},
 		"handlebars": {
@@ -13022,11 +13788,187 @@
 				"pathe": "^0.2.0"
 			},
 			"dependencies": {
+				"@esbuild/linux-loong64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+					"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+					"dev": true,
+					"optional": true
+				},
 				"defu": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/defu/-/defu-6.0.0.tgz",
-					"integrity": "sha512-t2MZGLf1V2rV4VBZbWIaXKdX/mUcYW0n2znQZoADBkGGxYL8EWqCuCZBmJPJ/Yy9fofJkyuuSuo5GSwo0XdEgw==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.0.tgz",
+					"integrity": "sha512-pOFYRTIhoKujrmbTRhcW5lYQLBXw/dlTwfI8IguF1QCDJOcJzNH1w+YFjxqy6BAuJrClTy6MUE8q+oKJ2FLsIw==",
 					"dev": true
+				},
+				"esbuild": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+					"integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+					"dev": true,
+					"requires": {
+						"@esbuild/linux-loong64": "0.14.54",
+						"esbuild-android-64": "0.14.54",
+						"esbuild-android-arm64": "0.14.54",
+						"esbuild-darwin-64": "0.14.54",
+						"esbuild-darwin-arm64": "0.14.54",
+						"esbuild-freebsd-64": "0.14.54",
+						"esbuild-freebsd-arm64": "0.14.54",
+						"esbuild-linux-32": "0.14.54",
+						"esbuild-linux-64": "0.14.54",
+						"esbuild-linux-arm": "0.14.54",
+						"esbuild-linux-arm64": "0.14.54",
+						"esbuild-linux-mips64le": "0.14.54",
+						"esbuild-linux-ppc64le": "0.14.54",
+						"esbuild-linux-riscv64": "0.14.54",
+						"esbuild-linux-s390x": "0.14.54",
+						"esbuild-netbsd-64": "0.14.54",
+						"esbuild-openbsd-64": "0.14.54",
+						"esbuild-sunos-64": "0.14.54",
+						"esbuild-windows-32": "0.14.54",
+						"esbuild-windows-64": "0.14.54",
+						"esbuild-windows-arm64": "0.14.54"
+					}
+				},
+				"esbuild-android-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+					"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-android-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+					"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+					"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+					"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+					"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+					"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-32": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+					"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+					"integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+					"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+					"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-mips64le": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+					"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-ppc64le": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+					"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-riscv64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+					"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-s390x": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+					"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-netbsd-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+					"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-openbsd-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+					"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-sunos-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+					"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-32": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+					"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+					"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+					"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -13049,9 +13991,9 @@
 			"dev": true
 		},
 		"msw": {
-			"version": "0.44.2",
-			"resolved": "https://registry.npmjs.org/msw/-/msw-0.44.2.tgz",
-			"integrity": "sha512-u8wjzzcMWouoZtuIShCwx4M3wFF5sBAV1f8K4a0WX8kiihFjzl89IKE1VYmTclLyMIwpOq8qQ1HTpuh2BFX/3A==",
+			"version": "0.45.0",
+			"resolved": "https://registry.npmjs.org/msw/-/msw-0.45.0.tgz",
+			"integrity": "sha512-aZgYsSJWYLHj5wZs/g640GP5AK6gfHC6dKTED8bforKZx10IJ+b0z7Y+0infEKD4gNT3orj7tiUZe4pxgpY0SQ==",
 			"dev": true,
 			"requires": {
 				"@mswjs/cookies": "^0.2.2",
@@ -13062,7 +14004,6 @@
 				"chalk": "4.1.1",
 				"chokidar": "^3.4.2",
 				"cookie": "^0.4.2",
-				"graphql": "^16.3.0",
 				"headers-polyfill": "^3.0.4",
 				"inquirer": "^8.2.0",
 				"is-node-process": "^1.0.1",
@@ -13376,14 +14317,14 @@
 			"dev": true
 		},
 		"object.assign": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-			"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
 			"dev": true,
 			"requires": {
-				"call-bind": "^1.0.0",
-				"define-properties": "^1.1.3",
-				"has-symbols": "^1.0.1",
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			}
 		},
@@ -13657,9 +14598,9 @@
 			}
 		},
 		"postcss": {
-			"version": "8.4.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-			"integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+			"version": "8.4.16",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
+			"integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
 			"dev": true,
 			"requires": {
 				"nanoid": "^3.3.4",
@@ -13967,9 +14908,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.77.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
-			"integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -14157,9 +15098,9 @@
 			}
 		},
 		"size-limit": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.0.0.tgz",
-			"integrity": "sha512-344dzCZZiTz+N0WS801SNG/qd8MCa6dzJhsj8gLQg4JlmddwUdi/Ol0HfliEVL7jgtOz8fNgDeB2+14xwalvVA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/size-limit/-/size-limit-8.0.1.tgz",
+			"integrity": "sha512-VHrozqkQTYfcv1OlZIRIL0x6f+xhZ3TT+RTXC5AvKn/yA+3PIWERrKWqHMJPD7G/Vi0SuBtWAn3IvCGx2/UB1g==",
 			"dev": true,
 			"requires": {
 				"bytes-iec": "^3.1.1",
@@ -14285,9 +15226,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-			"integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+			"integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
 			"dev": true
 		},
 		"split": {
@@ -14561,9 +15502,9 @@
 			"dev": true
 		},
 		"tinyspy": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.0.tgz",
-			"integrity": "sha512-FI5B2QdODQYDRjfuLF+OrJ8bjWRMCXokQPcwKm0W3IzcbUmBNv536cQc7eXGoAuXphZwgx1DFbqImwzz08Fnhw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-1.0.2.tgz",
+			"integrity": "sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==",
 			"dev": true
 		},
 		"tmp": {
@@ -14668,9 +15609,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.16.3",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
-			"integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
+			"integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
 			"dev": true,
 			"optional": true
 		},
@@ -14810,18 +15751,194 @@
 			}
 		},
 		"vite": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.4.tgz",
-			"integrity": "sha512-NU304nqnBeOx2MkQnskBQxVsa0pRAH5FphokTGmyy8M3oxbvw7qAXts2GORxs+h/2vKsD+osMhZ7An6yK6F1dA==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
+			"integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
 			"dev": true,
 			"requires": {
 				"esbuild": "^0.14.47",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.4.14",
+				"postcss": "^8.4.16",
 				"resolve": "^1.22.1",
-				"rollup": "^2.75.6"
+				"rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
 			},
 			"dependencies": {
+				"@esbuild/linux-loong64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz",
+					"integrity": "sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.54.tgz",
+					"integrity": "sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==",
+					"dev": true,
+					"requires": {
+						"@esbuild/linux-loong64": "0.14.54",
+						"esbuild-android-64": "0.14.54",
+						"esbuild-android-arm64": "0.14.54",
+						"esbuild-darwin-64": "0.14.54",
+						"esbuild-darwin-arm64": "0.14.54",
+						"esbuild-freebsd-64": "0.14.54",
+						"esbuild-freebsd-arm64": "0.14.54",
+						"esbuild-linux-32": "0.14.54",
+						"esbuild-linux-64": "0.14.54",
+						"esbuild-linux-arm": "0.14.54",
+						"esbuild-linux-arm64": "0.14.54",
+						"esbuild-linux-mips64le": "0.14.54",
+						"esbuild-linux-ppc64le": "0.14.54",
+						"esbuild-linux-riscv64": "0.14.54",
+						"esbuild-linux-s390x": "0.14.54",
+						"esbuild-netbsd-64": "0.14.54",
+						"esbuild-openbsd-64": "0.14.54",
+						"esbuild-sunos-64": "0.14.54",
+						"esbuild-windows-32": "0.14.54",
+						"esbuild-windows-64": "0.14.54",
+						"esbuild-windows-arm64": "0.14.54"
+					}
+				},
+				"esbuild-android-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.54.tgz",
+					"integrity": "sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-android-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.54.tgz",
+					"integrity": "sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.54.tgz",
+					"integrity": "sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-darwin-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.54.tgz",
+					"integrity": "sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.54.tgz",
+					"integrity": "sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-freebsd-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.54.tgz",
+					"integrity": "sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-32": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.54.tgz",
+					"integrity": "sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.54.tgz",
+					"integrity": "sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.54.tgz",
+					"integrity": "sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.54.tgz",
+					"integrity": "sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-mips64le": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.54.tgz",
+					"integrity": "sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-ppc64le": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.54.tgz",
+					"integrity": "sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-riscv64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.54.tgz",
+					"integrity": "sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-linux-s390x": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.54.tgz",
+					"integrity": "sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-netbsd-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.54.tgz",
+					"integrity": "sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-openbsd-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.54.tgz",
+					"integrity": "sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-sunos-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.54.tgz",
+					"integrity": "sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-32": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.54.tgz",
+					"integrity": "sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.54.tgz",
+					"integrity": "sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==",
+					"dev": true,
+					"optional": true
+				},
+				"esbuild-windows-arm64": {
+					"version": "0.14.54",
+					"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.54.tgz",
+					"integrity": "sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==",
+					"dev": true,
+					"optional": true
+				},
 				"resolve": {
 					"version": "1.22.1",
 					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -14832,23 +15949,32 @@
 						"path-parse": "^1.0.7",
 						"supports-preserve-symlinks-flag": "^1.0.0"
 					}
+				},
+				"rollup": {
+					"version": "2.77.3",
+					"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+					"integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+					"dev": true,
+					"requires": {
+						"fsevents": "~2.3.2"
+					}
 				}
 			}
 		},
 		"vitest": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.21.0.tgz",
-			"integrity": "sha512-+BQB2swk4wQdw5loOoL8esIYh/1ifAliuwj2HWHNE2F8SAl/jF7/aoCJBoXGSf/Ws19k3pH4NrWeVtcSwM0j2w==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-0.22.1.tgz",
+			"integrity": "sha512-+x28YTnSLth4KbXg7MCzoDAzPJlJex7YgiZbUh6YLp0/4PqVZ7q7/zyfdL0OaPtKTpNiQFPpMC8Y2MSzk8F7dw==",
 			"dev": true,
 			"requires": {
-				"@types/chai": "^4.3.1",
+				"@types/chai": "^4.3.3",
 				"@types/chai-subset": "^1.3.3",
 				"@types/node": "*",
 				"chai": "^4.3.6",
 				"debug": "^4.3.4",
 				"local-pkg": "^0.4.2",
 				"tinypool": "^0.2.4",
-				"tinyspy": "^1.0.0",
+				"tinyspy": "^1.0.2",
 				"vite": "^2.9.12 || ^3.0.0-0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -50,30 +50,30 @@
 	},
 	"dependencies": {
 		"@prismicio/helpers": "^2.3.3",
-		"@prismicio/types": "^0.2.1"
+		"@prismicio/types": "^0.2.3"
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.1.1",
-		"@size-limit/preset-small-lib": "^8.0.0",
+		"@size-limit/preset-small-lib": "^8.0.1",
 		"@types/sinon": "^10.0.13",
-		"@typescript-eslint/eslint-plugin": "^5.32.0",
-		"@typescript-eslint/parser": "^5.32.0",
+		"@typescript-eslint/eslint-plugin": "^5.34.0",
+		"@typescript-eslint/parser": "^5.34.0",
+		"@vitest/coverage-c8": "^0.22.1",
 		"abort-controller": "^3.0.0",
-		"c8": "^7.12.0",
-		"eslint": "^8.21.0",
+		"eslint": "^8.22.0",
 		"eslint-config-prettier": "^8.5.0",
 		"eslint-plugin-prettier": "^4.2.1",
 		"eslint-plugin-tsdoc": "^0.2.16",
-		"msw": "^0.44.2",
+		"msw": "^0.45.0",
 		"node-fetch": "^3.2.10",
 		"nyc": "^15.1.0",
 		"prettier": "^2.7.1",
 		"prettier-plugin-jsdoc": "^0.3.38",
 		"siroc": "^0.16.0",
-		"size-limit": "^8.0.0",
+		"size-limit": "^8.0.1",
 		"standard-version": "^9.5.0",
 		"typescript": "^4.7.4",
-		"vitest": "^0.21.0"
+		"vitest": "^0.22.1"
 	},
 	"engines": {
 		"node": ">=12.13.0"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		coverage: {
+			provider: "c8",
 			reporter: ["lcovonly", "text"],
 		},
 		setupFiles: ["./test/__setup__"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR upgrades all dependencies except the following:

- `prettier-plugin-jsdoc`: An ESM-related issue with its underlying `mdast-util-from-markdown` dependency breaks the Prettier plugin. For now, the plugin should be kept on `^0.3`.

  **Related issue**: https://github.com/hosseinmd/prettier-plugin-jsdoc/issues/173

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦭
