### PR TITLE
fix: widen `AbortSignal` for greater support of fetch implementations

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -68,18 +68,8 @@ export type FetchLike = (
 // different AbortSignal implementations. The types of each property are not
 // important to validate since it is blindly passed to a given `fetch()`
 // function.
-export type AbortSignalLike = {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	aborted: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	addEventListener: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	removeEventListener: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	dispatchEvent: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	onabort: any;
-};
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AbortSignalLike = any;
 
 /**
  * The minimum required properties from RequestInit.
@@ -88,7 +78,17 @@ export interface RequestInitLike {
 	headers?: Record<string, string>;
 	// `null` is included to match TypeScript's `fetch()` type in `lib.dom.d.ts`.
 	// See: https://github.com/microsoft/TypeScript/blob/3328feb7991f358e245088d48b64ad9da8f015e2/lib/lib.dom.d.ts#L1515-L1518
-	signal?: AbortSignalLike | null;
+
+	/**
+	 * An object that allows you to abort a `fetch()` request if needed via an
+	 * `AbortController` object
+	 *
+	 * {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal}
+	 */
+	// NOTE: `AbortSignalLike` is `any`! It is left as `AbortSignalLike`
+	// for backwards compatibility (the type is exported) and to signal to
+	// other readers that this should be an AbortSignal-like object.
+	signal?: AbortSignalLike;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,8 +76,6 @@ export type AbortSignalLike = any;
  */
 export interface RequestInitLike {
 	headers?: Record<string, string>;
-	// `null` is included to match TypeScript's `fetch()` type in `lib.dom.d.ts`.
-	// See: https://github.com/microsoft/TypeScript/blob/3328feb7991f358e245088d48b64ad9da8f015e2/lib/lib.dom.d.ts#L1515-L1518
 
 	/**
 	 * An object that allows you to abort a `fetch()` request if needed via an


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR widens `AbortSignal`'s type to support a wider range of `fetch()` implementations.

Unfortunately, a common type among `fetch()` implementations could not be found, so **the `signal` parameter is now typed as `any`**.

Fixes: #254

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐴
