### PR TITLE
ci: run type tests against various TypeScript version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,78 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  ci:
+  prepare:
+    name: Prepare ({{ matrix.os}}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
-
     strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [14]
+
+    steps:
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Cache node_modules
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ matrix.os }}-node-v${{ matrix.node }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '/package-lock.json')) }}
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+  suite:
+    needs: prepare
+    name: Suite ({{ matrix.os}}, Node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node: [14]
+
+    steps:
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Retrieve node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ matrix.os }}-node-v${{ matrix.node }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '/package-lock.json')) }}
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit
+        run: npm run unit
+
+      - name: Build
+        run: npm run build
+
+      - name: Coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 14
+        uses: codecov/codecov-action@v3
+
+  types:
+    needs: prepare
+    name: Types ({{ matrix.os}}, Node ${{ matrix.node }}, TypeScript ${{ matrix.typescript }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node: [14]
@@ -21,37 +89,45 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - name: Cache node_modules
-        uses: actions/cache@v2
+      - name: Retrieve node_modules
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ matrix.os }}-node-v${{ matrix.node }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '/package-lock.json')) }}
 
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci
-
-      - name: Lint
-        if: matrix.typescript == '4.9'
-        run: npm run lint
+      - name: Overwrite TypeScript
+        run: npm install --save-dev typescript@${{ matrix.typescript }}
 
       - name: Types
-        run: npm install --save-dev typescript@${{ matrix.typescript }} && npm run types
+        run: npm run types
 
-      - name: Unit
-        if: matrix.typescript == '4.9'
-        run: npm run unit
+  size:
+    needs: prepare
+    name: Size ({{ matrix.os}}, Node ${{ matrix.node }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node: [14]
 
-      - name: Build
-        if: matrix.typescript == '4.9'
-        run: npm run build
+    steps:
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
 
-      - name: Coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.node == 14 && matrix.typescript == '4.9'
-        uses: codecov/codecov-action@v3
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Retrieve node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ matrix.os }}-node-v${{ matrix.node }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '/package-lock.json')) }}
 
       - name: Size
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.node == 14 && matrix.typescript == '4.9'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.node == 14
         uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: ci
 
-on: [push, pull_request]
+on: push
 
 jobs:
   prepare:
-    name: Prepare ({{ matrix.os}}, Node ${{ matrix.node }})
+    name: Prepare (${{ matrix.os}}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -33,7 +33,7 @@ jobs:
 
   suite:
     needs: prepare
-    name: Suite ({{ matrix.os}}, Node ${{ matrix.node }})
+    name: Suite (${{ matrix.os}}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -71,7 +71,7 @@ jobs:
 
   types:
     needs: prepare
-    name: Types ({{ matrix.os}}, Node ${{ matrix.node }}, TypeScript ${{ matrix.typescript }})
+    name: Types (${{ matrix.os}}, Node ${{ matrix.node }}, TS ${{ matrix.typescript }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -103,7 +103,7 @@ jobs:
 
   size:
     needs: prepare
-    name: Size ({{ matrix.os}}, Node ${{ matrix.node }})
+    name: Size (${{ matrix.os}}, Node ${{ matrix.node }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           key: ${{ matrix.os }}-node-v${{ matrix.node }}-deps-${{ hashFiles(format('{0}{1}', github.workspace, '/package-lock.json')) }}
 
       - name: Overwrite TypeScript
-        run: npm install --save-dev typescript@${{ matrix.typescript }}
+        run: npm install --no-save typescript@${{ matrix.typescript }} && npx tsc --version
 
       - name: Types
         run: npm run types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [14, 16, 18]
 
     steps:
       - name: Set up Node
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node: [14]
+        node: [14, 16, 18]
 
     steps:
       - name: Set up Node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [14]
+        typescript: ["4.5", "4.6", "4.7", "4.8", "4.9"]
 
     steps:
       - name: Set up Node
@@ -37,23 +38,26 @@ jobs:
         run: npm ci
 
       - name: Lint
+        if: matrix.typescript == "4.9"
         run: npm run lint
 
       - name: Types
-        run: npm run types
+        run: npm install --save-dev typescript@${{ matrix.typescript }} && npm run types
 
       - name: Unit
+        if: matrix.typescript == "4.9"
         run: npm run unit
 
       - name: Build
+        if: matrix.typescript == "4.9"
         run: npm run build
 
       - name: Coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.node == 14
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 14 && matrix.typescript == "4.9"
         uses: codecov/codecov-action@v3
 
       - name: Size
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.node == 14
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.node == 14 && matrix.typescript == "4.9"
         uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: ci
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node: [14]
-        typescript: ["4.5", "4.6", "4.7", "4.8", "4.9"]
+        typescript: ['4.5', '4.6', '4.7', '4.8', '4.9']
 
     steps:
       - name: Set up Node
@@ -32,26 +32,26 @@ jobs:
         run: npm ci
 
       - name: Lint
-        if: matrix.typescript == "4.9"
+        if: matrix.typescript == '4.9'
         run: npm run lint
 
       - name: Types
         run: npm install --save-dev typescript@${{ matrix.typescript }} && npm run types
 
       - name: Unit
-        if: matrix.typescript == "4.9"
+        if: matrix.typescript == '4.9'
         run: npm run unit
 
       - name: Build
-        if: matrix.typescript == "4.9"
+        if: matrix.typescript == '4.9'
         run: npm run build
 
       - name: Coverage
-        if: matrix.os == 'ubuntu-latest' && matrix.node == 14 && matrix.typescript == "4.9"
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 14 && matrix.typescript == '4.9'
         uses: codecov/codecov-action@v3
 
       - name: Size
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.node == 14 && matrix.typescript == "4.9"
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest' && matrix.node == 14 && matrix.typescript == '4.9'
         uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/helpers/asLink.ts
+++ b/src/helpers/asLink.ts
@@ -69,7 +69,8 @@ export const asLink = <
 	const linkField =
 		// prettier-ignore
 		(
-			// @ts-expect-error - Bug in TypeScript 4.9: https://github.com/microsoft/TypeScript/issues/51501
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore - Bug in TypeScript 4.9: https://github.com/microsoft/TypeScript/issues/51501
 			// TODO: Remove the `prettier-ignore` comment when this bug is fixed.
 			"link_type" in linkFieldOrDocument
 				? linkFieldOrDocument

--- a/test/__testutils__/testAnyGetMethod.ts
+++ b/test/__testutils__/testAnyGetMethod.ts
@@ -65,7 +65,7 @@ export const testAnyGetMethodFactory = (
 				break;
 
 			default:
-				throw new Error("Unknown mode `%o`", mode);
+				throw new Error(`Unknown mode \`${mode}\``);
 		}
 	});
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR runs type tests across various version of TypeScript (4.5 through 4.9).

It fixes the few errors pointed out by those new tests.
- A minor constructor error
- Exceptionally uses `@ts-ignore` instead of `@ts-expect-error` for a specific TypeScript 4.9 issue (not sure about it, but apparently https://github.com/microsoft/TypeScript/issues/51501 got fixed on the upcoming 5.0 version, someone suggested to backport it to 4.9 but for now it has been ignored)

This PR also refactors a bit the CI architecture to accommodate those new tests. It's a bit more complex but about as fast when not running `size-limit` and faster when running it.

![image](https://user-images.githubusercontent.com/25330882/214322621-6e60bfb1-9d90-41fc-9a7a-53846320da72.png)

Resolves: #274

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
