### PR TITLE
fix: add soft support for Node.js 12

### DIFF
--- a/src/buildQueryURL.ts
+++ b/src/buildQueryURL.ts
@@ -288,7 +288,7 @@ export const buildQueryURL = (
 	// Iterate over each parameter and add it to the URL. In some cases, the
 	// parameter value needs to be transformed to fit the REST API.
 	for (const k in params) {
-		const name = (RENAMED_PARAMS[k as keyof typeof RENAMED_PARAMS] ??
+		const name = (RENAMED_PARAMS[k as keyof typeof RENAMED_PARAMS] ||
 			k) as ValidParamName;
 
 		let value = params[k as keyof typeof params];

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -588,7 +588,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	): Promise<TDocument> {
 		const actualParams = { ...params };
 		if (!(params && params.page) && !params?.pageSize) {
-			actualParams.pageSize = this.defaultParams?.pageSize ?? 1;
+			actualParams.pageSize =
+				this.defaultParams?.pageSize == null ? 1 : this.defaultParams?.pageSize;
 		}
 		const url = await this.buildQueryURL(actualParams);
 		const result = await this.fetch<Query<TDocument>>(url, params);

--- a/src/helpers/documentToLinkField.ts
+++ b/src/helpers/documentToLinkField.ts
@@ -27,11 +27,11 @@ export const documentToLinkField = <
 	return {
 		link_type: LinkType.Document,
 		id: prismicDocument.id,
-		uid: prismicDocument.uid ?? undefined,
+		uid: prismicDocument.uid || undefined,
 		type: prismicDocument.type,
 		tags: prismicDocument.tags,
 		lang: prismicDocument.lang,
-		url: prismicDocument.url ?? undefined,
+		url: prismicDocument.url == null ? undefined : prismicDocument.url,
 		slug: prismicDocument.slugs?.[0], // Slug field is not available with GraphQl
 		// The REST API does not include a `data` property if the data
 		// object is empty.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR introduces undocumented support for Node.js 12. Although Node.js 12 is already past its end-of-life (EOL), with Node.js 14's EOL coming within the next month, some developers are still using build systems that do not recognize all Node.js 14 features.

Specifically in `@prismicio/client`, the use of the nullish coelescing operator (`??`) throws errors in older build systems (think: a Babel configuration that isn't aware of the operator).

This PR removes all use of `??` and replaces it with `||` or a nullish ternary check where appropriate.

This PR does **not** mean we officially support Node.js 12. We officially only support LTS versions of Node.js. However, because the change in the PR is simple, we can make an exception in this case.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐁
