### PR TITLE
feat: add `getToolbarSrc()` helper

### DIFF
--- a/src/getToolbarSrc.ts
+++ b/src/getToolbarSrc.ts
@@ -1,0 +1,50 @@
+import { PrismicError } from "./errors/PrismicError";
+
+import { isRepositoryName } from "./isRepositoryName";
+
+/**
+ * Returns the URL for a Prismic repository's Prismic Toolbar script. Use the
+ * URL to inject the script into your app.
+ *
+ * @example
+ *
+ * ```typescriptreact
+ * // In Next.js apps, use `next/script` in your `app/layout.tsx` file.
+ *
+ * import Script from "next/script";
+ * import * as prismic from '@prismicio/client'
+ *
+ * export default function RootLayout({
+ * 	children,
+ * }: {
+ * 	children: React.ReactNode,
+ * }) {
+ * 	const toolbarSrc = prismic.getToolbarSrc("my-repo");
+ *
+ * 	return (
+ * 		<html lang="en">
+ * 			<body>{children}</body>
+ * 			<Script src={toolbarSrc} />
+ * 		</html>
+ * 	);
+ * }
+ * ```
+ *
+ * @param repositoryName - The name of the Prismic repository. For example,
+ *   `"my-repo"` if the repository URL is `my-repo.prismic.io`.
+ *
+ * @returns The URL for the given Prismic repository's Prismic Toolbar script.
+ */
+export const getToolbarSrc = <TRepositoryName extends string>(
+	repositoryName: TRepositoryName,
+): `https://static.cdn.prismic.io/prismic.js?new=true&repo=${TRepositoryName}` => {
+	if (isRepositoryName(repositoryName)) {
+		return `https://static.cdn.prismic.io/prismic.js?new=true&repo=${repositoryName}` as const;
+	} else {
+		throw new PrismicError(
+			`An invalid Prismic repository name was given: ${repositoryName}`,
+			undefined,
+			undefined,
+		);
+	}
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@ export { isRepositoryName } from "./isRepositoryName";
 export { isRepositoryEndpoint } from "./isRepositoryEndpoint";
 export { buildQueryURL } from "./buildQueryURL";
 
+// Toolbar helpers.
+export { getToolbarSrc } from "./getToolbarSrc";
+
 // Query filters API.
 /**
  * @deprecated Renamed to `filter`

--- a/test/getToolbarSrc.test.ts
+++ b/test/getToolbarSrc.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from "vitest";
+
+import * as prismic from "../src";
+
+it("returns a URL for the Prismic Toolbar script", () => {
+	const endpoint = prismic.getToolbarSrc("qwerty");
+
+	expect(endpoint).toBe(
+		"https://static.cdn.prismic.io/prismic.js?new=true&repo=qwerty",
+	);
+});
+
+it("throws if an invalid repository name is given", () => {
+	expect(() => {
+		prismic.getToolbarSrc("this is invalid");
+	}).toThrowError(
+		/An invalid Prismic repository name was given: this is invalid/i,
+	);
+	expect(() => {
+		prismic.getToolbarSrc("this is invalid");
+	}).toThrowError(prismic.PrismicError);
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a `getToolbarSrc()` helper that returns a Prismic repository's Prismic Toolbar script URL.

```typescript
import * as prismic from "@prismicio/client";

const toolbarSrc = prismic.getToolbarSrc("my-repo-name");
// => https://static.cdn.prismic.io/prismic.js?new=true&repo=my-repo-name
```

### Motivation

This helper will replace `@prismicio/react`'s `<PrismicToolbar>` when used in React Server Components environments; in Server Components environments, `<script>` elements should be rendered on the server, which `<PrismicToolbar>` is not able to do.

Providing `getToolbarSrc()` allows a developer to get the Prismic Toolbar's script URL and render the `<script>` using their framework's conventions. In a Next.js app, for example, a developer would use `next/script`.

```tsx
import * as prismic from "@prismicio/client";
import Script from "next/script";

export default function Page() {
  const toolbarSrc = prismic.getToolbarSrc("my-repo-name");

  return (
    <main>
      <Script src={toolbarSrc} />
    </main>
  );
}
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐋
