### PR TITLE
feat: add `optimize` options

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -1257,8 +1257,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 			url.searchParams.set(
 				OPTIMIZE_REPOSITORY_REQUESTS_VALID_UNTIL_PARAMETER_NAME,
 				(
-					Math.ceil(Math.floor(Date.now() / REPOSITORY_CACHE_TTL)) *
-					REPOSITORY_CACHE_TTL
+					Math.floor(Date.now() / REPOSITORY_CACHE_TTL) *
+					REPOSITORY_CACHE_TTL + REPOSITORY_CACHE_TTL
 				).toString(),
 			);
 		}

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -522,14 +522,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 		this.brokenRoute = options.brokenRoute;
 		this.defaultParams = options.defaultParams;
 		this.optimize = {
-			repositoryRequests:
-				options.optimize?.repositoryRequests == null
-					? true
-					: options.optimize?.repositoryRequests,
-			concurentRequests:
-				options.optimize?.concurentRequests == null
-					? true
-					: options.optimize?.concurentRequests,
+			repositoryRequests: options.optimize?.repositoryRequests ?? true,
+			concurentRequests: options.optimize?.concurentRequests ?? true,
 		};
 
 		if (options.ref) {
@@ -631,7 +625,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * @returns A paginated response containing the result of the query.
 	 */
 	async get<TDocument extends TDocuments>(
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<Query<TDocument>> {
 		const url = await this.buildQueryURL(params);
 
@@ -653,12 +647,11 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *   The first result of the query, if any.
 	 */
 	async getFirst<TDocument extends TDocuments>(
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<TDocument> {
 		const actualParams = { ...params };
 		if (!(params && params.page) && !params?.pageSize) {
-			actualParams.pageSize =
-				this.defaultParams?.pageSize == null ? 1 : this.defaultParams?.pageSize;
+			actualParams.pageSize = this.defaultParams?.pageSize ?? 1;
 		}
 		const url = await this.buildQueryURL(actualParams);
 		const result = await this.fetch<Query<TDocument>>(url, params);
@@ -697,7 +690,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	async dangerouslyGetAll<TDocument extends TDocuments>(
 		params: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
-			FetchParams = {},
+			FetchParams &
+			OptimizeParams = {},
 	): Promise<TDocument[]> {
 		const { limit = Infinity, ...actualParams } = params;
 		const resolvedParams = {
@@ -751,7 +745,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 */
 	async getByID<TDocument extends TDocuments>(
 		id: string,
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<TDocument> {
 		return await this.getFirst<TDocument>(
 			appendFilters(params, filter.at("document.id", id)),
@@ -784,7 +778,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 */
 	async getByIDs<TDocument extends TDocuments>(
 		ids: string[],
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<Query<TDocument>> {
 		return await this.get<TDocument>(
 			appendFilters(params, filter.in("document.id", ids)),
@@ -819,7 +813,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 */
 	async getAllByIDs<TDocument extends TDocuments>(
 		ids: string[],
-		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
+		params?: Partial<BuildQueryURLArgs> &
+			GetAllParams &
+			FetchParams &
+			OptimizeParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendFilters(params, filter.in("document.id", ids)),
@@ -855,7 +852,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	>(
 		documentType: TDocumentType,
 		uid: string,
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<ExtractDocumentType<TDocument, TDocumentType>> {
 		return await this.getFirst<ExtractDocumentType<TDocument, TDocumentType>>(
 			appendFilters(params, [
@@ -897,7 +894,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	>(
 		documentType: TDocumentType,
 		uids: string[],
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<Query<ExtractDocumentType<TDocument, TDocumentType>>> {
 		return await this.get<ExtractDocumentType<TDocument, TDocumentType>>(
 			appendFilters(params, [
@@ -941,7 +938,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	>(
 		documentType: TDocumentType,
 		uids: string[],
-		params?: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams,
+		params?: Partial<BuildQueryURLArgs> &
+			GetAllParams &
+			FetchParams &
+			OptimizeParams,
 	): Promise<ExtractDocumentType<TDocument, TDocumentType>[]> {
 		return await this.dangerouslyGetAll<
 			ExtractDocumentType<TDocument, TDocumentType>
@@ -980,7 +980,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 		TDocumentType extends TDocument["type"] = TDocument["type"],
 	>(
 		documentType: TDocumentType,
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<ExtractDocumentType<TDocument, TDocumentType>> {
 		return await this.getFirst<ExtractDocumentType<TDocument, TDocumentType>>(
 			appendFilters(params, typeFilter(documentType)),
@@ -1010,7 +1010,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 		TDocumentType extends TDocument["type"] = TDocument["type"],
 	>(
 		documentType: TDocumentType,
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<Query<ExtractDocumentType<TDocument, TDocumentType>>> {
 		return await this.get<ExtractDocumentType<TDocument, TDocumentType>>(
 			appendFilters(params, typeFilter(documentType)),
@@ -1043,7 +1043,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 		documentType: TDocumentType,
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
-			FetchParams,
+			FetchParams &
+			OptimizeParams,
 	): Promise<ExtractDocumentType<TDocument, TDocumentType>[]> {
 		return await this.dangerouslyGetAll<
 			ExtractDocumentType<TDocument, TDocumentType>
@@ -1070,7 +1071,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 */
 	async getByTag<TDocument extends TDocuments>(
 		tag: string,
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<Query<TDocument>> {
 		return await this.get<TDocument>(
 			appendFilters(params, someTagsFilter(tag)),
@@ -1099,7 +1100,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 		tag: string,
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
-			FetchParams,
+			FetchParams &
+			OptimizeParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendFilters(params, someTagsFilter(tag)),
@@ -1124,7 +1126,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 */
 	async getByEveryTag<TDocument extends TDocuments>(
 		tags: string[],
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<Query<TDocument>> {
 		return await this.get<TDocument>(
 			appendFilters(params, everyTagFilter(tags)),
@@ -1154,7 +1156,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 		tags: string[],
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
-			FetchParams,
+			FetchParams &
+			OptimizeParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendFilters(params, everyTagFilter(tags)),
@@ -1181,7 +1184,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 */
 	async getBySomeTags<TDocument extends TDocuments>(
 		tags: string[],
-		params?: Partial<BuildQueryURLArgs> & FetchParams,
+		params?: Partial<BuildQueryURLArgs> & FetchParams & OptimizeParams,
 	): Promise<Query<TDocument>> {
 		return await this.get<TDocument>(
 			appendFilters(params, someTagsFilter(tags)),
@@ -1212,7 +1215,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 		tags: string[],
 		params?: Partial<Omit<BuildQueryURLArgs, "page">> &
 			GetAllParams &
-			FetchParams,
+			FetchParams &
+			OptimizeParams,
 	): Promise<TDocument[]> {
 		return await this.dangerouslyGetAll<TDocument>(
 			appendFilters(params, someTagsFilter(tags)),
@@ -1225,7 +1229,9 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns Repository metadata.
 	 */
-	async getRepository(params?: FetchParams): Promise<Repository> {
+	async getRepository(
+		params?: FetchParams & OptimizeParams,
+	): Promise<Repository> {
 		// TODO: Restore when Authorization header support works in browsers with CORS.
 		// return await this.fetch<Repository>(this.endpoint);
 
@@ -1235,7 +1241,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 			url.searchParams.set("access_token", this.accessToken);
 		}
 
-		if (this.optimize.repositoryRequests) {
+		if (
+			params?.optimize?.repositoryRequests ??
+			this.optimize.repositoryRequests
+		) {
 			url.searchParams.set(
 				OPTIMIZE_REPOSITORY_REQUESTS_TIMESTAMP_PARAMETER_NAME,
 				Date.now().toString(),
@@ -1254,7 +1263,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns A list of all refs for the Prismic repository.
 	 */
-	async getRefs(params?: FetchParams): Promise<Ref[]> {
+	async getRefs(params?: FetchParams & OptimizeParams): Promise<Ref[]> {
 		const repository = await this.getRepository(params);
 
 		return repository.refs;
@@ -1267,7 +1276,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns The ref with a matching ID, if it exists.
 	 */
-	async getRefByID(id: string, params?: FetchParams): Promise<Ref> {
+	async getRefByID(
+		id: string,
+		params?: FetchParams & OptimizeParams,
+	): Promise<Ref> {
 		const refs = await this.getRefs(params);
 
 		return findRefByID(refs, id);
@@ -1280,7 +1292,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns The ref with a matching label, if it exists.
 	 */
-	async getRefByLabel(label: string, params?: FetchParams): Promise<Ref> {
+	async getRefByLabel(
+		label: string,
+		params?: FetchParams & OptimizeParams,
+	): Promise<Ref> {
 		const refs = await this.getRefs(params);
 
 		return findRefByLabel(refs, label);
@@ -1292,7 +1307,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns The repository's master ref.
 	 */
-	async getMasterRef(params?: FetchParams): Promise<Ref> {
+	async getMasterRef(params?: FetchParams & OptimizeParams): Promise<Ref> {
 		const refs = await this.getRefs(params);
 
 		return findMasterRef(refs);
@@ -1304,7 +1319,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns A list of all Releases for the Prismic repository.
 	 */
-	async getReleases(params?: FetchParams): Promise<Ref[]> {
+	async getReleases(params?: FetchParams & OptimizeParams): Promise<Ref[]> {
 		const refs = await this.getRefs(params);
 
 		return refs.filter((ref) => !ref.isMasterRef);
@@ -1317,7 +1332,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns The Release with a matching ID, if it exists.
 	 */
-	async getReleaseByID(id: string, params?: FetchParams): Promise<Ref> {
+	async getReleaseByID(
+		id: string,
+		params?: FetchParams & OptimizeParams,
+	): Promise<Ref> {
 		const releases = await this.getReleases(params);
 
 		return findRefByID(releases, id);
@@ -1330,7 +1348,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns The ref with a matching label, if it exists.
 	 */
-	async getReleaseByLabel(label: string, params?: FetchParams): Promise<Ref> {
+	async getReleaseByLabel(
+		label: string,
+		params?: FetchParams & OptimizeParams,
+	): Promise<Ref> {
 		const releases = await this.getReleases(params);
 
 		return findRefByLabel(releases, label);
@@ -1341,7 +1362,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns A list of all tags used in the repository.
 	 */
-	async getTags(params?: FetchParams): Promise<string[]> {
+	async getTags(params?: FetchParams & OptimizeParams): Promise<string[]> {
 		try {
 			const tagsForm = await this.getCachedRepositoryForm("tags", params);
 
@@ -1369,7 +1390,9 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	async buildQueryURL({
 		signal,
 		...params
-	}: Partial<BuildQueryURLArgs> & FetchParams = {}): Promise<string> {
+	}: Partial<BuildQueryURLArgs> &
+		FetchParams &
+		OptimizeParams = {}): Promise<string> {
 		const ref = params.ref || (await this.getResolvedRefString());
 		const integrationFieldsRef =
 			params.integrationFieldsRef ||
@@ -1407,7 +1430,9 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *   session. The user should be redirected to this URL.
 	 */
 	async resolvePreviewURL<LinkResolverReturnType>(
-		args: ResolvePreviewArgs<LinkResolverReturnType> & FetchParams,
+		args: ResolvePreviewArgs<LinkResolverReturnType> &
+			FetchParams &
+			OptimizeParams,
 	): Promise<string> {
 		let documentID: string | undefined | null = args.documentID;
 		let previewToken: string | undefined | null = args.previewToken;
@@ -1437,6 +1462,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 
 		if (documentID != null && previewToken != null) {
 			const document = await this.getByID(documentID, {
+				optimize: args.optimize,
 				signal: args.signal,
 				ref: previewToken,
 				lang: "*",
@@ -1644,8 +1670,13 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns Cached repository metadata.
 	 */
-	private async getCachedRepository(params?: FetchParams): Promise<Repository> {
-		if (this.optimize.repositoryRequests) {
+	private async getCachedRepository(
+		params?: FetchParams & OptimizeParams,
+	): Promise<Repository> {
+		if (
+			params?.optimize?.repositoryRequests ??
+			this.optimize.repositoryRequests
+		) {
 			if (
 				!this.cachedRepository ||
 				Date.now() >= this.cachedRepositoryExpiration
@@ -1671,7 +1702,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 */
 	private async getCachedRepositoryForm(
 		name: string,
-		params?: FetchParams,
+		params?: FetchParams & OptimizeParams,
 	): Promise<Form> {
 		const cachedRepository = await this.getCachedRepository(params);
 		const form = cachedRepository.forms[name];
@@ -1710,7 +1741,9 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 *
 	 * @returns The ref to use during a query.
 	 */
-	private async getResolvedRefString(params?: FetchParams): Promise<string> {
+	private async getResolvedRefString(
+		params?: FetchParams & OptimizeParams,
+	): Promise<string> {
 		if (this.refState.autoPreviewsEnabled) {
 			let previewRef: string | undefined;
 
@@ -1772,11 +1805,11 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 */
 	private async fetch<T = unknown>(
 		url: string,
-		params: FetchParams = {},
+		params: FetchParams & OptimizeParams = {},
 	): Promise<T> {
 		let res: FetchJobResult;
 
-		if (this.optimize.concurentRequests) {
+		if (params.optimize?.concurentRequests ?? this.optimize.concurentRequests) {
 			let job: Promise<FetchJobResult>;
 
 			const fetchJobKeyInstance = new URL(url);

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -1257,8 +1257,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 			url.searchParams.set(
 				OPTIMIZE_REPOSITORY_REQUESTS_VALID_UNTIL_PARAMETER_NAME,
 				(
-					Math.floor(Date.now() / REPOSITORY_CACHE_TTL) *
-					REPOSITORY_CACHE_TTL + REPOSITORY_CACHE_TTL
+					Math.floor(Date.now() / REPOSITORY_CACHE_TTL) * REPOSITORY_CACHE_TTL +
+					REPOSITORY_CACHE_TTL
 				).toString(),
 			);
 		}

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -306,7 +306,7 @@ type OptimizeParams = {
 		 *
 		 * @defaultValue `true`
 		 */
-		concurentRequests?: boolean;
+		concurrentRequests?: boolean;
 	};
 };
 
@@ -523,7 +523,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 		this.defaultParams = options.defaultParams;
 		this.optimize = {
 			repositoryRequests: options.optimize?.repositoryRequests ?? true,
-			concurentRequests: options.optimize?.concurentRequests ?? true,
+			concurrentRequests: options.optimize?.concurrentRequests ?? true,
 		};
 
 		if (options.ref) {
@@ -1389,14 +1389,17 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 */
 	async buildQueryURL({
 		signal,
+		optimize,
 		...params
 	}: Partial<BuildQueryURLArgs> &
 		FetchParams &
 		OptimizeParams = {}): Promise<string> {
-		const ref = params.ref || (await this.getResolvedRefString());
+		const ref =
+			params.ref || (await this.getResolvedRefString({ signal, optimize }));
 		const integrationFieldsRef =
 			params.integrationFieldsRef ||
-			(await this.getCachedRepository({ signal })).integrationFieldsRef ||
+			(await this.getCachedRepository({ signal, optimize }))
+				.integrationFieldsRef ||
 			undefined;
 
 		return buildQueryURL(this.endpoint, {
@@ -1809,7 +1812,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	): Promise<T> {
 		let res: FetchJobResult;
 
-		if (params.optimize?.concurentRequests ?? this.optimize.concurentRequests) {
+		if (
+			params.optimize?.concurrentRequests ??
+			this.optimize.concurrentRequests
+		) {
 			let job: Promise<FetchJobResult>;
 
 			const fetchJobKeyInstance = new URL(url);

--- a/test/__testutils__/testConcurrentMethod.ts
+++ b/test/__testutils__/testConcurrentMethod.ts
@@ -1,4 +1,4 @@
-import { expect, it, vi } from "vitest";
+import { TestContext, expect, it, vi } from "vitest";
 
 import { rest } from "msw";
 import fetch from "node-fetch";
@@ -13,7 +13,7 @@ import * as prismic from "../../src";
 type TestConcurrentMethodArgs = {
 	run: (
 		client: prismic.Client,
-		signal?: prismic.AbortSignalLike,
+		params?: Parameters<prismic.Client["get"]>[0],
 	) => Promise<unknown>;
 	mode:
 		| "get"
@@ -24,113 +24,156 @@ type TestConcurrentMethodArgs = {
 		| "NOT-SHARED___graphQL";
 };
 
+const runTest = async (
+	ctx: TestContext,
+	args: TestConcurrentMethodArgs,
+	clientParams?: Parameters<prismic.Client["get"]>[0],
+) => {
+	const fetchSpy = vi.fn(fetch);
+	const controller1 = new AbortController();
+	const controller2 = new AbortController();
+
+	const ref1 = ctx.mock.api.ref({ isMasterRef: true });
+	const ref2 = ctx.mock.api.ref({ isMasterRef: false });
+	ref2.id = "id";
+	ref2.label = "label";
+	const repositoryResponse = ctx.mock.api.repository();
+	repositoryResponse.refs = [ref1, ref2];
+
+	const queryResponse = createPagedQueryResponses({ ctx });
+
+	mockPrismicRestAPIV2({
+		ctx,
+		repositoryResponse,
+		queryResponse,
+		// A small delay is needed to simulate a real network
+		// request. Without the delay, network requests would
+		// not be shared.
+		queryDelay: 10,
+	});
+
+	const client = createTestClient({ clientConfig: { fetch: fetchSpy } });
+
+	const graphqlURL = `https://${createRepositoryName()}.cdn.prismic.io/graphql`;
+	const graphqlResponse = { foo: "bar" };
+	ctx.server.use(
+		rest.get(graphqlURL, (req, res, ctx) => {
+			if (req.headers.get("Prismic-Ref") === ref1.ref) {
+				return res(ctx.json(graphqlResponse));
+			}
+		}),
+	);
+
+	await Promise.all([
+		// Shared
+		args.run(client),
+		args.run(client),
+
+		// Shared
+		args.run(client, { ...clientParams, signal: controller1.signal }),
+		args.run(client, { ...clientParams, signal: controller1.signal }),
+
+		// Shared
+		args.run(client, { ...clientParams, signal: controller2.signal }),
+		args.run(client, { ...clientParams, signal: controller2.signal }),
+	]);
+
+	// Not shared
+	await args.run(client);
+	await args.run(client);
+
+	// `get` methods use a total of 6 requests:
+	// - 1x /api/v2 (shared across all requests)
+	// - 5x /api/v2/documents/search
+
+	// `getAll` methods use a total of 11 requests:
+	// - 1x /api/v2 (shared across all requests)
+	// - 10x /api/v2/documents/search
+
+	const hasConcurrentRequestsEnabled =
+		clientParams?.optimize?.concurentRequests ?? true;
+
+	switch (args.mode) {
+		case "get": {
+			expect(fetchSpy.mock.calls.length).toBe(
+				hasConcurrentRequestsEnabled ? 6 : 8,
+			);
+
+			break;
+		}
+
+		case "getAll": {
+			expect(fetchSpy.mock.calls.length).toBe(
+				hasConcurrentRequestsEnabled ? 11 : 15,
+			);
+
+			break;
+		}
+
+		case "repository": {
+			expect(fetchSpy.mock.calls.length).toBe(
+				hasConcurrentRequestsEnabled ? 5 : 7,
+			);
+
+			break;
+		}
+
+		case "tags": {
+			expect(fetchSpy.mock.calls.length).toBe(
+				hasConcurrentRequestsEnabled ? 8 : 12,
+			);
+
+			break;
+		}
+
+		case "resolvePreview": {
+			expect(fetchSpy.mock.calls.length).toBe(
+				hasConcurrentRequestsEnabled ? 8 : 10,
+			);
+
+			break;
+		}
+
+		// GraphQL requests are not shared.
+		case "NOT-SHARED___graphQL": {
+			expect(fetchSpy.mock.calls.length).toBe(9);
+
+			break;
+		}
+
+		default: {
+			throw new Error(`Invalid mode: ${args.mode}`);
+		}
+	}
+};
+
 export const testConcurrentMethod = (
 	description: string,
 	args: TestConcurrentMethodArgs,
 ): void => {
-	it.concurrent(description, async (ctx) => {
-		const fetchSpy = vi.fn(fetch);
-		const controller1 = new AbortController();
-		const controller2 = new AbortController();
-
-		const ref1 = ctx.mock.api.ref({ isMasterRef: true });
-		const ref2 = ctx.mock.api.ref({ isMasterRef: false });
-		ref2.id = "id";
-		ref2.label = "label";
-		const repositoryResponse = ctx.mock.api.repository();
-		repositoryResponse.refs = [ref1, ref2];
-
-		const queryResponse = createPagedQueryResponses({ ctx });
-
-		mockPrismicRestAPIV2({
-			ctx,
-			repositoryResponse,
-			queryResponse,
-			// A small delay is needed to simulate a real network
-			// request. Without the delay, network requests would
-			// not be shared.
-			queryDelay: 10,
-		});
-
-		const client = createTestClient({ clientConfig: { fetch: fetchSpy } });
-
-		const graphqlURL = `https://${createRepositoryName()}.cdn.prismic.io/graphql`;
-		const graphqlResponse = { foo: "bar" };
-		ctx.server.use(
-			rest.get(graphqlURL, (req, res, ctx) => {
-				if (req.headers.get("Prismic-Ref") === ref1.ref) {
-					return res(ctx.json(graphqlResponse));
-				}
-			}),
-		);
-
-		await Promise.all([
-			// Shared
-			args.run(client),
-			args.run(client),
-
-			// Shared
-			args.run(client, controller1.signal),
-			args.run(client, controller1.signal),
-
-			// Shared
-			args.run(client, controller2.signal),
-			args.run(client, controller2.signal),
-		]);
-
-		// Not shared
-		await args.run(client);
-		await args.run(client);
-
-		// `get` methods use a total of 6 requests:
-		// - 1x /api/v2 (shared across all requests)
-		// - 5x /api/v2/documents/search
-
-		// `getAll` methods use a total of 11 requests:
-		// - 1x /api/v2 (shared across all requests)
-		// - 10x /api/v2/documents/search
-
-		switch (args.mode) {
-			case "get": {
-				expect(fetchSpy.mock.calls.length).toBe(6);
-
-				break;
-			}
-
-			case "getAll": {
-				expect(fetchSpy.mock.calls.length).toBe(11);
-
-				break;
-			}
-
-			case "repository": {
-				expect(fetchSpy.mock.calls.length).toBe(5);
-
-				break;
-			}
-
-			case "tags": {
-				expect(fetchSpy.mock.calls.length).toBe(8);
-
-				break;
-			}
-
-			case "resolvePreview": {
-				expect(fetchSpy.mock.calls.length).toBe(8);
-
-				break;
-			}
-
-			// GraphQL requests are not shared.
-			case "NOT-SHARED___graphQL": {
-				expect(fetchSpy.mock.calls.length).toBe(9);
-
-				break;
-			}
-
-			default: {
-				throw new Error(`Invalid mode: ${args.mode}`);
-			}
-		}
+	it.concurrent(`${description} (default)`, async (ctx) => {
+		await runTest(ctx, args);
 	});
+
+	it.concurrent(
+		`${description} (optimize.concurrentRequests = true)`,
+		async (ctx) => {
+			await runTest(ctx, args, {
+				optimize: {
+					concurentRequests: true,
+				},
+			});
+		},
+	);
+
+	it.concurrent(
+		`${description} (optimize.concurrentRequests = false)`,
+		async (ctx) => {
+			await runTest(ctx, args, {
+				optimize: {
+					concurentRequests: false,
+				},
+			});
+		},
+	);
 };

--- a/test/__testutils__/testGetTTL.ts
+++ b/test/__testutils__/testGetTTL.ts
@@ -28,6 +28,7 @@ type GetContext = {
 type TestGetWithinTTLArgs = {
 	getContext: GetContext;
 	beforeFirstGet: (args: { client: prismic.Client }) => void;
+	requestParams?: Parameters<prismic.Client["get"]>[0];
 };
 
 export const testGetWithinTTL = (

--- a/test/client-dangerouslyGetAll.test.ts
+++ b/test/client-dangerouslyGetAll.test.ts
@@ -196,6 +196,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.dangerouslyGetAll({ signal }),
+	run: (client, params) => client.dangerouslyGetAll(params),
 	mode: "getAll",
 });

--- a/test/client-get.test.ts
+++ b/test/client-get.test.ts
@@ -58,6 +58,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.get({ signal }),
+	run: (client, params) => client.get(params),
 	mode: "get",
 });

--- a/test/client-get.test.ts
+++ b/test/client-get.test.ts
@@ -1,3 +1,9 @@
+import { expect, it, vi } from "vitest";
+
+import fetch from "node-fetch";
+
+import { createTestClient } from "./__testutils__/createClient";
+import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
@@ -52,6 +58,79 @@ testGetMethod("merges params and default params if provided", {
 		lang: "fr-fr",
 	},
 });
+
+it("uses cached repository metadata within the client's repository cache TTL", async (ctx) => {
+	const fetchSpy = vi.fn(fetch);
+
+	const client = createTestClient({ clientConfig: { fetch: fetchSpy } });
+
+	const repositoryResponse1 = ctx.mock.api.repository();
+	repositoryResponse1.refs = [ctx.mock.api.ref({ isMasterRef: true })];
+	mockPrismicRestAPIV2({ ctx, repositoryResponse: repositoryResponse1 });
+
+	await client.get();
+
+	// This response response will not be used.
+	const repositoryResponse2 = ctx.mock.api.repository();
+	repositoryResponse2.refs = [ctx.mock.api.ref({ isMasterRef: true })];
+	mockPrismicRestAPIV2({ ctx, repositoryResponse: repositoryResponse2 });
+
+	await client.get();
+
+	const getRequests = fetchSpy.mock.calls
+		.filter(
+			(call) =>
+				new URL(call[0] as string).pathname === "/api/v2/documents/search",
+		)
+		.map((call) => call[0] as string);
+
+	expect(new URL(getRequests[0]).searchParams.get("ref")).toBe(
+		repositoryResponse1.refs[0].ref,
+	);
+	expect(new URL(getRequests[1]).searchParams.get("ref")).toBe(
+		repositoryResponse1.refs[0].ref,
+	);
+});
+
+it("does not use the cached repository metadata within the client's repository cache TTL when optimize.repositoryRequests is disabled", async (ctx) => {
+	const fetchSpy = vi.fn(fetch);
+
+	const client = createTestClient({
+		clientConfig: {
+			fetch: fetchSpy,
+			optimize: {
+				repositoryRequests: false,
+			},
+		},
+	});
+
+	const repositoryResponse1 = ctx.mock.api.repository();
+	repositoryResponse1.refs = [ctx.mock.api.ref({ isMasterRef: true })];
+	mockPrismicRestAPIV2({ ctx, repositoryResponse: repositoryResponse1 });
+
+	await client.get();
+
+	// This response response will be used on the second request.
+	const repositoryResponse2 = ctx.mock.api.repository();
+	repositoryResponse2.refs = [ctx.mock.api.ref({ isMasterRef: true })];
+	mockPrismicRestAPIV2({ ctx, repositoryResponse: repositoryResponse2 });
+
+	await client.get();
+
+	const getRequests = fetchSpy.mock.calls
+		.filter(
+			(call) =>
+				new URL(call[0] as string).pathname === "/api/v2/documents/search",
+		)
+		.map((call) => call[0] as string);
+
+	expect(new URL(getRequests[0]).searchParams.get("ref")).toBe(
+		repositoryResponse1.refs[0].ref,
+	);
+	expect(new URL(getRequests[1]).searchParams.get("ref")).toBe(
+		repositoryResponse2.refs[0].ref,
+	);
+}, 10000);
 
 testAbortableMethod("is abortable with an AbortController", {
 	run: (client, signal) => client.get({ signal }),

--- a/test/client-getAllByEveryTag.test.ts
+++ b/test/client-getAllByEveryTag.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getAllByEveryTag(["foo", "bar"], { signal }),
+	run: (client, params) => client.getAllByEveryTag(["foo", "bar"], params),
 	mode: "getAll",
 });

--- a/test/client-getAllByIDs.test.ts
+++ b/test/client-getAllByIDs.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getAllByIDs(["id1", "id2"], { signal }),
+	run: (client, params) => client.getAllByIDs(["id1", "id2"], params),
 	mode: "getAll",
 });

--- a/test/client-getAllBySomeTags.test.ts
+++ b/test/client-getAllBySomeTags.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getAllBySomeTags(["foo", "bar"], { signal }),
+	run: (client, params) => client.getAllBySomeTags(["foo", "bar"], params),
 	mode: "getAll",
 });

--- a/test/client-getAllByTag.test.ts
+++ b/test/client-getAllByTag.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getAllByTag("tag", { signal }),
+	run: (client, params) => client.getAllByTag("tag", params),
 	mode: "getAll",
 });

--- a/test/client-getAllByType.test.ts
+++ b/test/client-getAllByType.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getAllByType("type", { signal }),
+	run: (client, params) => client.getAllByType("type", params),
 	mode: "getAll",
 });

--- a/test/client-getAllByUIDs.test.ts
+++ b/test/client-getAllByUIDs.test.ts
@@ -36,7 +36,7 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) =>
-		client.getAllByUIDs("type", ["uid1", "uid2"], { signal }),
+	run: (client, params) =>
+		client.getAllByUIDs("type", ["uid1", "uid2"], params),
 	mode: "getAll",
 });

--- a/test/client-getByEveryTag.test.ts
+++ b/test/client-getByEveryTag.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getByEveryTag(["foo", "bar"], { signal }),
+	run: (client, params) => client.getByEveryTag(["foo", "bar"], params),
 	mode: "get",
 });

--- a/test/client-getByID.test.ts
+++ b/test/client-getByID.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getByID("id", { signal }),
+	run: (client, params) => client.getByID("id", params),
 	mode: "get",
 });

--- a/test/client-getByIDs.test.ts
+++ b/test/client-getByIDs.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getByIDs(["id1", "id2"], { signal }),
+	run: (client, params) => client.getByIDs(["id1", "id2"], params),
 	mode: "get",
 });

--- a/test/client-getBySomeTags.test.ts
+++ b/test/client-getBySomeTags.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getBySomeTags(["foo", "bar"], { signal }),
+	run: (client, params) => client.getBySomeTags(["foo", "bar"], params),
 	mode: "get",
 });

--- a/test/client-getByTag.test.ts
+++ b/test/client-getByTag.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getByTag("tag", { signal }),
+	run: (client, params) => client.getByTag("tag", params),
 	mode: "get",
 });

--- a/test/client-getByType.test.ts
+++ b/test/client-getByType.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getByType("type", { signal }),
+	run: (client, params) => client.getByType("type", params),
 	mode: "get",
 });

--- a/test/client-getByUID.test.ts
+++ b/test/client-getByUID.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getByUID("type", "uid", { signal }),
+	run: (client, params) => client.getByUID("type", "uid", params),
 	mode: "get",
 });

--- a/test/client-getByUIDs.test.ts
+++ b/test/client-getByUIDs.test.ts
@@ -36,7 +36,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) =>
-		client.getByUIDs("type", ["uid1", "uid2"], { signal }),
+	run: (client, params) => client.getByUIDs("type", ["uid1", "uid2"], params),
 	mode: "get",
 });

--- a/test/client-getFirst.test.ts
+++ b/test/client-getFirst.test.ts
@@ -98,6 +98,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getFirst({ signal }),
+	run: (client, params) => client.getFirst(params),
 	mode: "get",
 });

--- a/test/client-getMasterRef.test.ts
+++ b/test/client-getMasterRef.test.ts
@@ -27,6 +27,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getMasterRef({ signal }),
+	run: (client, params) => client.getMasterRef(params),
 	mode: "repository",
 });

--- a/test/client-getRefByID.test.ts
+++ b/test/client-getRefByID.test.ts
@@ -43,6 +43,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getRefByID("id", { signal }),
+	run: (client, params) => client.getRefByID("id", params),
 	mode: "repository",
 });

--- a/test/client-getRefByLabel.test.ts
+++ b/test/client-getRefByLabel.test.ts
@@ -43,6 +43,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getRefByLabel("label", { signal }),
+	run: (client, params) => client.getRefByLabel("label", params),
 	mode: "repository",
 });

--- a/test/client-getRefs.test.ts
+++ b/test/client-getRefs.test.ts
@@ -23,6 +23,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getRefs({ signal }),
+	run: (client, params) => client.getRefs(params),
 	mode: "repository",
 });

--- a/test/client-getReleaseById.test.ts
+++ b/test/client-getReleaseById.test.ts
@@ -41,6 +41,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getReleaseByID("id", { signal }),
+	run: (client, params) => client.getReleaseByID("id", params),
 	mode: "repository",
 });

--- a/test/client-getReleaseByLabel.test.ts
+++ b/test/client-getReleaseByLabel.test.ts
@@ -41,6 +41,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getReleaseByLabel("label", { signal }),
+	run: (client, params) => client.getReleaseByLabel("label", params),
 	mode: "repository",
 });

--- a/test/client-getReleases.test.ts
+++ b/test/client-getReleases.test.ts
@@ -25,6 +25,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getReleases({ signal }),
+	run: (client, params) => client.getReleases(params),
 	mode: "repository",
 });

--- a/test/client-getRepository.test.ts
+++ b/test/client-getRepository.test.ts
@@ -113,6 +113,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getRepository({ signal }),
+	run: (client, params) => client.getRepository(params),
 	mode: "repository",
 });

--- a/test/client-getRepository.test.ts
+++ b/test/client-getRepository.test.ts
@@ -59,7 +59,7 @@ it("uses a cache-busting URL parameter by default", async (ctx) => {
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const url = new URL(call![0] as string);
 
-	expect(url.searchParams.has("x-optimize-ts")).toBe(true);
+	expect(url.searchParams.has("x-valid-until")).toBe(true);
 });
 
 it("uses a cache-busting URL parameter when `optimizeRepositoryRequest` is `true`", async (ctx) => {
@@ -83,7 +83,7 @@ it("uses a cache-busting URL parameter when `optimizeRepositoryRequest` is `true
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const url = new URL(call![0] as string);
 
-	expect(url.searchParams.has("x-optimize-ts")).toBe(true);
+	expect(url.searchParams.has("x-valid-until")).toBe(true);
 });
 
 it("does not use a cache-busting URL parameter when `optimizeRepositoryRequest` is `false`", async (ctx) => {
@@ -107,7 +107,7 @@ it("does not use a cache-busting URL parameter when `optimizeRepositoryRequest` 
 	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 	const url = new URL(call![0] as string);
 
-	expect(url.searchParams.has("x-optimize-ts")).toBe(false);
+	expect(url.searchParams.has("x-valid-until")).toBe(false);
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getRepository.test.ts
+++ b/test/client-getRepository.test.ts
@@ -1,5 +1,7 @@
 import { expect, it, vi } from "vitest";
 
+import fetch from "node-fetch";
+
 import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";

--- a/test/client-getSingle.test.ts
+++ b/test/client-getSingle.test.ts
@@ -29,6 +29,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getSingle("type", { signal }),
+	run: (client, params) => client.getSingle("type", params),
 	mode: "get",
 });

--- a/test/client-getTags.test.ts
+++ b/test/client-getTags.test.ts
@@ -86,6 +86,6 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) => client.getTags({ signal }),
+	run: (client, params) => client.getTags(params),
 	mode: "tags",
 });

--- a/test/client-graphQLFetch.test.ts
+++ b/test/client-graphQLFetch.test.ts
@@ -213,10 +213,10 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("does not share concurrent equivalent network requests", {
-	run: (client, signal) =>
+	run: (client, params) =>
 		client.graphQLFetch(
 			`https://${createRepositoryName()}.cdn.prismic.io/graphql`,
-			{ signal },
+			params,
 		),
 	mode: "NOT-SHARED___graphQL",
 });

--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -233,9 +233,9 @@ testAbortableMethod("is abortable with an AbortController", {
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {
-	run: (client, signal) =>
+	run: (client, params) =>
 		client.resolvePreviewURL({
-			signal,
+			...params,
 			defaultURL: "defaultURL",
 			documentID: "foo",
 			previewToken,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a new `optimize` option to `createClient()` and all client methods that make requests to the Prismic API.

```typescript
const client = createClient({
  optimize: {
    /**
     * Determines if fetching repository metadata should be optimized. The
     * optimizations result in faster queries, less network requests, and more
     * accurate cache-busting.
     *
     * Only opt out of this optimization if you know what you are doing.
     *
     * @defaultValue `true`
     */
    repositoryRequests: true,

    /**
     * Determines if concurrent requests to the same URL should be optimized.
     * The optimizations result in less network requests and quicker responses.
     *
     * Only opt out of this optimization if you know what you are doing.
     *
     * @defaultValue `true`
     */
    concurentRequests: true,
  },
});

// `optimize` can be overridden on a per-request basis.
const page = await client.getByUID("page", "home", {
  optimize: {
    repositoryRequests: false,
    concurentRequests: false,
  },
});
```

All current optimizations are enabled by default.

- `repositoryRequests`: Caches successful requests to `/api/v2` internally for 5 seconds and forces external network caches to not cache `/api/v2` requests for 5 seconds.
- `concurrentRequests`: De-duplicates idential concurrent requests.

All optimizations except `repositoryRequests`'s "force external network caches to not cache" were already in place and were not configurable. This PR allows for explicitly opting out of these optimizations, which should only be done in very specific cases.

### Forcing external network caches to not cache `/api/v2`

A new optimization is introduced in this PR: requests to `/api/v2` are forcibly cache-busted by default after 5 seconds.

This is done by adding a per-request-unique URL parameter (`x-valid-until`) containing an epoch timestamp produced at the time of the request. The timestamp represents the time at which the request is no longer valid.

```
https://example-prismic-repo.cdn.prismic.io/api/v2?x-valid-until=1682556195000
```

The 5 second lifespan is not guaranteed. It is calculated by taking the timestamp at the time of the request, rounding down to the nearest 5 seconds, then adding 5 seconds. Treat it as an unguaranteed optimization that may not always be respected.

Only `/api/v2` requests are optimized. All `/api/v2/documents/search` requests are inherently cache-busted by the `ref` parameter.

The parameter is ignored within the concurrent requests job queue when `optimize.concurrentRequests` is enabled.

This new optimization was prompted by the need to forcibly opt out of [Next.js's new aggressive App Router `fetch()` caching](https://beta.nextjs.org/docs/data-fetching/caching).

### To discuss

1. **Is this PR over-engineered?**
   We technically only need to add the `x-valid-until` parameter to every network request with the option to opt out. The other `optimize` options are nice-to-haves to cover edge cases.

2. **Is `x-valid-until` the correct parameter name?**

3. **Is `optimize` the correct option name?**
   It was inspired by Vite's `optimizeDeps` option.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦥
