### PR TITLE
feat: support Web API `Request`s containing partial URLs

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -1467,8 +1467,15 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 				"url" in this.refState.httpRequest &&
 				this.refState.httpRequest.url
 			) {
-				const searchParams = new URL(this.refState.httpRequest.url)
-					.searchParams;
+				// Including "missing-host://" by default
+				// handles a case where Next.js Route Handlers
+				// only provide the pathname and search
+				// parameters in the `url` property
+				// (e.g. `/api/preview?foo=bar`).
+				const searchParams = new URL(
+					this.refState.httpRequest.url,
+					"missing-host://",
+				).searchParams;
 
 				documentID = documentID || searchParams.get("documentId");
 				previewToken = previewToken || searchParams.get("token");

--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -111,6 +111,39 @@ it("resolves a preview url using a Web API-based server req object", async (ctx)
 	expect(res).toBe(`/${document.uid}`);
 });
 
+it("resolves a preview url using a Web API-based server req object containing a URL without a host", async (ctx) => {
+	const seed = ctx.meta.name;
+	const document = { ...prismicM.value.document({ seed }), uid: seed };
+	const queryResponse = prismicM.api.query({ seed, documents: [document] });
+
+	const headers = new Headers();
+	const url = `/foo?documentId=${document.id}&token=${previewToken}`;
+	const req = {
+		headers,
+		url: url.toString(),
+	};
+
+	mockPrismicRestAPIV2({
+		queryResponse,
+		queryRequiredParams: {
+			ref: previewToken,
+			lang: "*",
+			pageSize: "1",
+			q: `[[at(document.id, "${document.id}")]]`,
+		},
+		ctx,
+	});
+
+	const client = createTestClient();
+	client.enableAutoPreviewsFromReq(req);
+	const res = await client.resolvePreviewURL({
+		linkResolver: (document) => `/${document.uid}`,
+		defaultURL: "defaultURL",
+	});
+
+	expect(res).toBe(`/${document.uid}`);
+});
+
 it("allows providing an explicit documentId and previewToken", async (ctx) => {
 	const seed = ctx.meta.name;
 	const document = { ...prismicM.value.document({ seed }), uid: seed };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for automatic preview support using Web API `Request`s containing partial URLs.

As an example, Next.js provides a `Request` instance to [Route Handlers](https://beta.nextjs.org/docs/routing/route-handlers). Its `url` property only contains the pathname and search paramters (e.g. `/foo?bar=baz`).

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐟
