### PR TITLE
feat: add `fetchOptions` parameter to control `fetch()`

### DIFF
--- a/test/__testutils__/testAbortableMethod.ts
+++ b/test/__testutils__/testAbortableMethod.ts
@@ -8,7 +8,7 @@ import * as prismic from "../../src";
 type TestAbortableMethodArgs = {
 	run: (
 		client: prismic.Client,
-		signal: prismic.AbortSignalLike,
+		params?: Parameters<prismic.Client["get"]>[0],
 	) => Promise<unknown>;
 };
 
@@ -25,7 +25,31 @@ export const testAbortableMethod = (
 		const client = createTestClient();
 
 		await expect(async () => {
-			await args.run(client, controller.signal);
+			await args.run(client, {
+				fetchOptions: {
+					signal: controller.signal,
+				},
+			});
 		}).rejects.toThrow(/aborted/i);
 	});
+
+	// TODO: Remove once the `signal` parameter is removed in favor of
+	// `fetchOptions.signal`.
+	it.concurrent(
+		`${description} (using deprecated \`signal\` param)`,
+		async (ctx) => {
+			const controller = new AbortController();
+			controller.abort();
+
+			mockPrismicRestAPIV2({ ctx });
+
+			const client = createTestClient();
+
+			await expect(async () => {
+				await args.run(client, {
+					signal: controller.signal,
+				});
+			}).rejects.toThrow(/aborted/i);
+		},
+	);
 };

--- a/test/__testutils__/testFetchOptions.ts
+++ b/test/__testutils__/testFetchOptions.ts
@@ -1,0 +1,83 @@
+import { expect, it, vi } from "vitest";
+
+import { createTestClient } from "./createClient";
+import { mockPrismicRestAPIV2 } from "./mockPrismicRestAPIV2";
+
+import * as prismic from "../../src";
+
+type TestFetchOptionsArgs = {
+	run: (
+		client: prismic.Client,
+		params?: Parameters<prismic.Client["get"]>[0],
+	) => Promise<unknown>;
+};
+
+export const testFetchOptions = (
+	description: string,
+	args: TestFetchOptionsArgs,
+): void => {
+	it.concurrent(`${description} (on client)`, async (ctx) => {
+		const abortController = new AbortController();
+
+		const fetchSpy = vi.fn(fetch);
+		const fetchOptions: prismic.RequestInitLike = {
+			cache: "no-store",
+			headers: {
+				foo: "bar",
+			},
+			signal: abortController.signal,
+		};
+
+		mockPrismicRestAPIV2({
+			ctx,
+			queryResponse: ctx.mock.api.query({
+				documents: [ctx.mock.value.document()],
+			}),
+		});
+
+		const client = createTestClient({
+			clientConfig: {
+				fetch: fetchSpy,
+				fetchOptions,
+			},
+		});
+
+		await args.run(client);
+
+		for (const [input, init] of fetchSpy.mock.calls) {
+			expect(init, input.toString()).toStrictEqual(fetchOptions);
+		}
+	});
+
+	it.concurrent(`${description} (on method)`, async (ctx) => {
+		const abortController = new AbortController();
+
+		const fetchSpy = vi.fn(fetch);
+		const fetchOptions: prismic.RequestInitLike = {
+			cache: "no-store",
+			headers: {
+				foo: "bar",
+			},
+			signal: abortController.signal,
+		};
+
+		mockPrismicRestAPIV2({
+			ctx,
+			queryResponse: ctx.mock.api.query({
+				documents: [ctx.mock.value.document()],
+			}),
+		});
+
+		const client = createTestClient({
+			clientConfig: {
+				fetch: fetchSpy,
+			},
+		});
+
+		await args.run(client, { fetchOptions });
+
+		for (const [input, init] of fetchSpy.mock.calls) {
+			expect(init, input.toString()).toStrictEqual(fetchOptions);
+		}
+	});
+};

--- a/test/__testutils__/testFetchOptions.ts
+++ b/test/__testutils__/testFetchOptions.ts
@@ -1,5 +1,7 @@
 import { expect, it, vi } from "vitest";
 
+import fetch from "node-fetch";
+
 import { createTestClient } from "./createClient";
 import { mockPrismicRestAPIV2 } from "./mockPrismicRestAPIV2";
 

--- a/test/client-dangerouslyGetAll.test.ts
+++ b/test/client-dangerouslyGetAll.test.ts
@@ -192,7 +192,7 @@ it("does not throttle single page queries", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.dangerouslyGetAll({ signal }),
+	run: (client, params) => client.dangerouslyGetAll(params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-dangerouslyGetAll.test.ts
+++ b/test/client-dangerouslyGetAll.test.ts
@@ -6,6 +6,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 /**
  * The number of milliseconds in which a multi-page `getAll` (e.g. `getAll`,
@@ -189,6 +190,10 @@ it("does not throttle single page queries", async (ctx) => {
 		minTime <= totalTime && totalTime <= maxTime,
 		`Total time should be between ${minTime}ms and ${maxTime}ms (inclusive), but was ${totalTime}ms`,
 	).toBe(true);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.dangerouslyGetAll(params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-get.test.ts
+++ b/test/client-get.test.ts
@@ -7,6 +7,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("resolves a query", {
 	run: (client) => client.get(),
@@ -131,6 +132,10 @@ it("does not use the cached repository metadata within the client's repository c
 		repositoryResponse2.refs[0].ref,
 	);
 }, 10000);
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.get(params),
+});
 
 testAbortableMethod("is abortable with an AbortController", {
 	run: (client, params) => client.get(params),

--- a/test/client-get.test.ts
+++ b/test/client-get.test.ts
@@ -133,7 +133,7 @@ it("does not use the cached repository metadata within the client's repository c
 }, 10000);
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.get({ signal }),
+	run: (client, params) => client.get(params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getAllByEveryTag.test.ts
+++ b/test/client-getAllByEveryTag.test.ts
@@ -25,7 +25,7 @@ testGetAllMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllByEveryTag(["foo", "bar"], { signal }),
+	run: (client, params) => client.getAllByEveryTag(["foo", "bar"], params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getAllByEveryTag.test.ts
+++ b/test/client-getAllByEveryTag.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by every tag from paginated response", {
 	run: (client) => client.getAllByEveryTag(["foo", "bar"]),
@@ -22,6 +23,10 @@ testGetAllMethod("includes params if provided", {
 		lang: "*",
 		q: `[[at(document.tags, ["foo", "bar"])]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByEveryTag(["foo", "bar"], params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getAllByIDs.test.ts
+++ b/test/client-getAllByIDs.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by IDs from paginated response", {
 	run: (client) => client.getAllByIDs(["id1", "id2"]),
@@ -22,6 +23,10 @@ testGetAllMethod("includes params if provided", {
 		lang: "*",
 		q: `[[in(document.id, ["id1", "id2"])]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByIDs(["id1", "id2"], params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getAllByIDs.test.ts
+++ b/test/client-getAllByIDs.test.ts
@@ -25,7 +25,7 @@ testGetAllMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllByIDs(["id1", "id2"], { signal }),
+	run: (client, params) => client.getAllByIDs(["id1", "id2"], params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getAllBySomeTags.test.ts
+++ b/test/client-getAllBySomeTags.test.ts
@@ -25,7 +25,7 @@ testGetAllMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllBySomeTags(["foo", "bar"], { signal }),
+	run: (client, params) => client.getAllBySomeTags(["foo", "bar"], params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getAllBySomeTags.test.ts
+++ b/test/client-getAllBySomeTags.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by some tags from paginated response", {
 	run: (client) => client.getAllBySomeTags(["foo", "bar"]),
@@ -22,6 +23,10 @@ testGetAllMethod("includes params if provided", {
 		lang: "*",
 		q: `[[any(document.tags, ["foo", "bar"])]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllBySomeTags(["foo", "bar"], params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getAllByTag.test.ts
+++ b/test/client-getAllByTag.test.ts
@@ -25,7 +25,7 @@ testGetAllMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllByTag("tag", { signal }),
+	run: (client, params) => client.getAllByTag("tag", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getAllByTag.test.ts
+++ b/test/client-getAllByTag.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by tag from paginated response", {
 	run: (client) => client.getAllByTag("tag"),
@@ -22,6 +23,10 @@ testGetAllMethod("includes params if provided", {
 		lang: "*",
 		q: `[[any(document.tags, ["tag"])]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByTag("tag", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getAllByType.test.ts
+++ b/test/client-getAllByType.test.ts
@@ -25,7 +25,7 @@ testGetAllMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllByType("type", { signal }),
+	run: (client, params) => client.getAllByType("type", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getAllByType.test.ts
+++ b/test/client-getAllByType.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by type from paginated response", {
 	run: (client) => client.getAllByType("type"),
@@ -22,6 +23,10 @@ testGetAllMethod("includes params if provided", {
 		lang: "*",
 		q: `[[at(document.type, "type")]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByType("type", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getAllByUIDs.test.ts
+++ b/test/client-getAllByUIDs.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by UIDs from paginated response", {
 	run: (client) => client.getAllByUIDs("type", ["uid1", "uid2"]),
@@ -28,6 +29,11 @@ testGetAllMethod("includes params if provided", {
 			`[[in(my.type.uid, ["uid1", "uid2"])]]`,
 		],
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) =>
+		client.getAllByUIDs("type", ["uid1", "uid2"], params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getAllByUIDs.test.ts
+++ b/test/client-getAllByUIDs.test.ts
@@ -31,8 +31,8 @@ testGetAllMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) =>
-		client.getAllByUIDs("type", ["uid1", "uid2"], { signal }),
+	run: (client, params) =>
+		client.getAllByUIDs("type", ["uid1", "uid2"], params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getByEveryTag.test.ts
+++ b/test/client-getByEveryTag.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by tag", {
 	run: (client) => client.getByEveryTag(["foo", "bar"]),
@@ -22,6 +23,10 @@ testGetMethod("includes params if provided", {
 		lang: "*",
 		q: `[[at(document.tags, ["foo", "bar"])]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByEveryTag(["foo", "bar"], params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getByEveryTag.test.ts
+++ b/test/client-getByEveryTag.test.ts
@@ -25,7 +25,7 @@ testGetMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByEveryTag(["foo", "bar"], { signal }),
+	run: (client, params) => client.getByEveryTag(["foo", "bar"], params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getByID.test.ts
+++ b/test/client-getByID.test.ts
@@ -25,7 +25,7 @@ testGetFirstMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByID("id", { signal }),
+	run: (client, params) => client.getByID("id", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getByID.test.ts
+++ b/test/client-getByID.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetFirstMethod("queries for document by ID", {
 	run: (client) => client.getByID("id"),
@@ -22,6 +23,10 @@ testGetFirstMethod("includes params if provided", {
 		lang: "*",
 		q: `[[at(document.id, "id")]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByID("id", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getByIDs.test.ts
+++ b/test/client-getByIDs.test.ts
@@ -25,7 +25,7 @@ testGetMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByIDs(["id1", "id2"], { signal }),
+	run: (client, params) => client.getByIDs(["id1", "id2"], params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getByIDs.test.ts
+++ b/test/client-getByIDs.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by IDs", {
 	run: (client) => client.getByIDs(["id1", "id2"]),
@@ -22,6 +23,10 @@ testGetMethod("includes params if provided", {
 		lang: "*",
 		q: `[[in(document.id, ["id1", "id2"])]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByIDs(["id1", "id2"], params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getBySomeTags.test.ts
+++ b/test/client-getBySomeTags.test.ts
@@ -25,7 +25,7 @@ testGetMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getBySomeTags(["foo", "bar"], { signal }),
+	run: (client, params) => client.getBySomeTags(["foo", "bar"], params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getBySomeTags.test.ts
+++ b/test/client-getBySomeTags.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by some tags", {
 	run: (client) => client.getBySomeTags(["foo", "bar"]),
@@ -22,6 +23,10 @@ testGetMethod("includes params if provided", {
 		lang: "*",
 		q: `[[any(document.tags, ["foo", "bar"])]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getBySomeTags(["foo", "bar"], params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getByTag.test.ts
+++ b/test/client-getByTag.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by tag", {
 	run: (client) => client.getByTag("tag"),
@@ -22,6 +23,10 @@ testGetMethod("includes params if provided", {
 		lang: "*",
 		q: `[[any(document.tags, ["tag"])]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByTag("tag", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getByTag.test.ts
+++ b/test/client-getByTag.test.ts
@@ -25,7 +25,7 @@ testGetMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByTag("tag", { signal }),
+	run: (client, params) => client.getByTag("tag", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getByType.test.ts
+++ b/test/client-getByType.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by type", {
 	run: (client) => client.getByType("type"),
@@ -22,6 +23,10 @@ testGetMethod("includes params if provided", {
 		lang: "*",
 		q: `[[at(document.type, "type")]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByType("type", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getByType.test.ts
+++ b/test/client-getByType.test.ts
@@ -25,7 +25,7 @@ testGetMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByType("type", { signal }),
+	run: (client, params) => client.getByType("type", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getByUID.test.ts
+++ b/test/client-getByUID.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetFirstMethod("queries for document by UID", {
 	run: (client) => client.getByUID("type", "uid"),
@@ -22,6 +23,10 @@ testGetFirstMethod("includes params if provided", {
 		lang: "*",
 		q: [`[[at(document.type, "type")]]`, `[[at(my.type.uid, "uid")]]`],
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByUID("type", "uid", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getByUID.test.ts
+++ b/test/client-getByUID.test.ts
@@ -25,7 +25,7 @@ testGetFirstMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByUID("type", "uid", { signal }),
+	run: (client, params) => client.getByUID("type", "uid", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getByUIDs.test.ts
+++ b/test/client-getByUIDs.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by UIDs", {
 	run: (client) => client.getByUIDs("type", ["uid1", "uid2"]),
@@ -28,6 +29,10 @@ testGetMethod("includes params if provided", {
 			`[[in(my.type.uid, ["uid1", "uid2"])]]`,
 		],
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByUIDs("type", ["uid1", "uid2"], params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getByUIDs.test.ts
+++ b/test/client-getByUIDs.test.ts
@@ -31,8 +31,7 @@ testGetMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) =>
-		client.getByUIDs("type", ["uid1", "uid2"], { signal }),
+	run: (client, params) => client.getByUIDs("type", ["uid1", "uid2"], params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getFirst.test.ts
+++ b/test/client-getFirst.test.ts
@@ -7,6 +7,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismic from "../src";
 
@@ -91,6 +92,10 @@ it("throws if no documents were returned", async (ctx) => {
 	await expect(() => client.getFirst()).rejects.toThrowError(
 		prismic.PrismicError,
 	);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getFirst(params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getFirst.test.ts
+++ b/test/client-getFirst.test.ts
@@ -94,7 +94,7 @@ it("throws if no documents were returned", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getFirst({ signal }),
+	run: (client, params) => client.getFirst(params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getMasterRef.test.ts
+++ b/test/client-getMasterRef.test.ts
@@ -4,6 +4,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns the master ref", async (ctx) => {
 	const masterRef = ctx.mock.api.ref({ isMasterRef: true });
@@ -20,6 +21,10 @@ it("returns the master ref", async (ctx) => {
 	const res = await client.getMasterRef();
 
 	expect(res).toStrictEqual(masterRef);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getMasterRef(params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getMasterRef.test.ts
+++ b/test/client-getMasterRef.test.ts
@@ -23,7 +23,7 @@ it("returns the master ref", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getMasterRef({ signal }),
+	run: (client, params) => client.getMasterRef(params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getRefByID.test.ts
+++ b/test/client-getRefByID.test.ts
@@ -39,7 +39,7 @@ it("throws if ref could not be found", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getRefByID("id", { signal }),
+	run: (client, params) => client.getRefByID("id", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getRefByID.test.ts
+++ b/test/client-getRefByID.test.ts
@@ -4,6 +4,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismic from "../src";
 
@@ -36,6 +37,10 @@ it("throws if ref could not be found", async (ctx) => {
 	await expect(() => client.getRefByID("non-existant")).rejects.toThrowError(
 		prismic.PrismicError,
 	);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getRefByID("id", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getRefByLabel.test.ts
+++ b/test/client-getRefByLabel.test.ts
@@ -4,6 +4,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismic from "../src";
 
@@ -36,6 +37,10 @@ it("throws if ref could not be found", async (ctx) => {
 	await expect(() => client.getRefByLabel("non-existant")).rejects.toThrowError(
 		prismic.PrismicError,
 	);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getRefByLabel("label", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getRefByLabel.test.ts
+++ b/test/client-getRefByLabel.test.ts
@@ -39,7 +39,7 @@ it("throws if ref could not be found", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getRefByLabel("label", { signal }),
+	run: (client, params) => client.getRefByLabel("label", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getRefs.test.ts
+++ b/test/client-getRefs.test.ts
@@ -4,6 +4,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns all refs", async (ctx) => {
 	const repositoryResponse = ctx.mock.api.repository();
@@ -16,6 +17,10 @@ it("returns all refs", async (ctx) => {
 	const res = await client.getRefs();
 
 	expect(res).toStrictEqual(repositoryResponse.refs);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getRefs(params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getRefs.test.ts
+++ b/test/client-getRefs.test.ts
@@ -19,7 +19,7 @@ it("returns all refs", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getRefs({ signal }),
+	run: (client, params) => client.getRefs(params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getReleaseById.test.ts
+++ b/test/client-getReleaseById.test.ts
@@ -4,6 +4,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismic from "../src";
 
@@ -34,6 +35,10 @@ it("throws if Release could not be found", async (ctx) => {
 	await expect(() =>
 		client.getReleaseByID("non-existant"),
 	).rejects.toThrowError(prismic.PrismicError);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getReleaseByID("id", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getReleaseById.test.ts
+++ b/test/client-getReleaseById.test.ts
@@ -37,7 +37,7 @@ it("throws if Release could not be found", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getReleaseByID("id", { signal }),
+	run: (client, params) => client.getReleaseByID("id", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getReleaseByLabel.test.ts
+++ b/test/client-getReleaseByLabel.test.ts
@@ -37,7 +37,7 @@ it("throws if Release could not be found", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getReleaseByLabel("label", { signal }),
+	run: (client, params) => client.getReleaseByLabel("label", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getReleaseByLabel.test.ts
+++ b/test/client-getReleaseByLabel.test.ts
@@ -4,6 +4,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismic from "../src";
 
@@ -34,6 +35,10 @@ it("throws if Release could not be found", async (ctx) => {
 	await expect(() =>
 		client.getReleaseByLabel("non-existant"),
 	).rejects.toThrowError(prismic.PrismicError);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getReleaseByLabel("label", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getReleases.test.ts
+++ b/test/client-getReleases.test.ts
@@ -4,6 +4,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns all Releases", async (ctx) => {
 	const repositoryResponse = ctx.mock.api.repository();
@@ -18,6 +19,10 @@ it("returns all Releases", async (ctx) => {
 	expect(res).toStrictEqual(
 		repositoryResponse.refs.filter((ref) => !ref.isMasterRef),
 	);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getReleases(params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getReleases.test.ts
+++ b/test/client-getReleases.test.ts
@@ -21,7 +21,7 @@ it("returns all Releases", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getReleases({ signal }),
+	run: (client, params) => client.getReleases(params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getRepository.test.ts
+++ b/test/client-getRepository.test.ts
@@ -6,6 +6,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 import * as prismic from "../src";
 
@@ -108,6 +109,10 @@ it("does not use a cache-busting URL parameter when `optimizeRepositoryRequest` 
 	const url = new URL(call![0] as string);
 
 	expect(url.searchParams.has("x-valid-until")).toBe(false);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getRepository(params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getRepository.test.ts
+++ b/test/client-getRepository.test.ts
@@ -111,7 +111,7 @@ it("does not use a cache-busting URL parameter when `optimizeRepositoryRequest` 
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getRepository({ signal }),
+	run: (client, params) => client.getRepository(params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getSingle.test.ts
+++ b/test/client-getSingle.test.ts
@@ -1,6 +1,7 @@
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetFirstMethod("queries for singleton document", {
 	run: (client) => client.getSingle("type"),
@@ -22,6 +23,10 @@ testGetFirstMethod("includes params if provided", {
 		lang: "*",
 		q: `[[at(document.type, "type")]]`,
 	},
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getSingle("type", params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getSingle.test.ts
+++ b/test/client-getSingle.test.ts
@@ -25,7 +25,7 @@ testGetFirstMethod("includes params if provided", {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getSingle("type", { signal }),
+	run: (client, params) => client.getSingle("type", params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-getTags.test.ts
+++ b/test/client-getTags.test.ts
@@ -6,6 +6,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns all tags", async (ctx) => {
 	const repositoryResponse = ctx.mock.api.repository();
@@ -79,6 +80,10 @@ it("sends access token if form endpoint is used", async (ctx) => {
 	const res = await client.getTags();
 
 	expect(res).toStrictEqual(tagsResponse);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getTags(params),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-getTags.test.ts
+++ b/test/client-getTags.test.ts
@@ -82,7 +82,7 @@ it("sends access token if form endpoint is used", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getTags({ signal }),
+	run: (client, params) => client.getTags(params),
 });
 
 testConcurrentMethod("shares concurrent equivalent network requests", {

--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -7,6 +7,7 @@ import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 const previewToken = "previewToken";
 
@@ -253,6 +254,16 @@ it("returns defaultURL if resolved URL is not a string", async (ctx) => {
 	});
 
 	expect(res).toBe(defaultURL);
+});
+
+testFetchOptions("supports fetch options", {
+	run: (client, params) =>
+		client.resolvePreviewURL({
+			...params,
+			defaultURL: "defaultURL",
+			documentID: "foo",
+			previewToken,
+		}),
 });
 
 testAbortableMethod("is abortable with an AbortController", {

--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -256,9 +256,9 @@ it("returns defaultURL if resolved URL is not a string", async (ctx) => {
 });
 
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) =>
+	run: (client, params) =>
 		client.resolvePreviewURL({
-			signal,
+			...params,
 			defaultURL: "defaultURL",
 			documentID: "foo",
 			previewToken,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds a new `fetchOptions` parameter to `createClient()` and all client methods that make network requests.

The parameter allows for customizing how `fetch()` is called.

```typescript
// Set `fetch()` options for every request.
const client = createClient("example-prismic-repo", {
  fetchOptions: {
    cache: "force-cache",
  },
});

// Set or override `fetch()` options for individual queries.
const page = await client.getByUID("page", "home", {
  fetchOptions: {
    cache: "no-store",
  },
});
```

### Supported options

The TypeScript types support a subset of the global `RequestInit` type:

- [`headers`](https://developer.mozilla.org/en-US/docs/Web/API/Request/headers) (only plain objects are supported)
- [`cache`](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache)
- [`signal`](https://developer.mozilla.org/en-US/docs/Web/API/Request/signal)

These three parameters have known real-world use cases, while others, like [`credentials`](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials), currently do not.

If we learn that other parameters are needed, we can add support for them in the future.

### Adding support for project-specific options

`@prismicio/client`'s type for `fetchOptions` can be augmented on a per-project basis using [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).

This is useful if a project needs to add support for a `RequestInit` property that is not supported by default. It is also useful if projects have project-specific `RequestInit` features that need to be added, like [Next.js' `next` parameter](https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate).

```typescript
// Adds `credentials` support.
declare module "@prismicio/client" {
  interface RequestInitLike {
    credentials?: RequestInit["credentials"];
  }
}

const client = createClient("example-prismic-repo", {
  fetchOptions: {
    credentials: "same-origin",
  },
});
```

### Deprecating `signal` parameter in favor of `fetchOptions.signal`

The `signal` parameter has been replaced by the more apt `fetchOptions.signal`.

```typescript
const controller = new AbortSignal();
const client = createClient("example-prismic-repo");

// New
await client.getByUID("page", "home", {
  fetchOptions: {
    signal: controller.signal,
  },
});

// Old
await client.getByUID("page", "home", {
  signal: controller.signal,
});
```

`signal` will continue to be supported, but has been marked as deprecated. Please migrate to `fetchOptions.signal`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐕
