### PR TITLE
feat: add `fetchOptions` parameter to control `fetch()`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -72,16 +72,23 @@ export type FetchLike = (
 export type AbortSignalLike = any;
 
 /**
- * The minimum required properties from RequestInit.
+ * A subset of RequestInit properties to configure a `fetch()` request.
  */
-export interface RequestInitLike {
+// Only options relevant to the client are included. Extending from the full
+// RequestInit would cause issues, such as accepting Header objects.
+//
+// An interface is used to allow other libraries to augment the type with
+// environment-specific types.
+export interface RequestInitLike extends Pick<RequestInit, "cache"> {
+	/**
+	 * An object literal to set the `fetch()` request's headers.
+	 */
 	headers?: Record<string, string>;
 
 	/**
-	 * An object that allows you to abort a `fetch()` request if needed via an
-	 * `AbortController` object
+	 * An AbortSignal to set the `fetch()` request's signal.
 	 *
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal}
+	 * See: https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal
 	 */
 	// NOTE: `AbortSignalLike` is `any`! It is left as `AbortSignalLike`
 	// for backwards compatibility (the type is exported) and to signal to

--- a/test/__testutils__/testAbortableMethod.ts
+++ b/test/__testutils__/testAbortableMethod.ts
@@ -1,21 +1,21 @@
-import { it, expect } from "vitest";
+import { expect, it } from "vitest";
 
-import { mockPrismicRestAPIV2 } from "./mockPrismicRestAPIV2";
 import { createTestClient } from "./createClient";
+import { mockPrismicRestAPIV2 } from "./mockPrismicRestAPIV2";
 
 import * as prismic from "../../src";
 
 type TestAbortableMethodArgs = {
 	run: (
 		client: prismic.Client,
-		signal: prismic.AbortSignalLike,
+		params?: Parameters<prismic.Client["get"]>[0],
 	) => Promise<unknown>;
 };
 
 export const testAbortableMethod = (
 	description: string,
 	args: TestAbortableMethodArgs,
-) => {
+): void => {
 	it.concurrent(description, async (ctx) => {
 		const controller = new AbortController();
 		controller.abort();
@@ -25,7 +25,31 @@ export const testAbortableMethod = (
 		const client = createTestClient();
 
 		await expect(async () => {
-			await args.run(client, controller.signal);
+			await args.run(client, {
+				fetchOptions: {
+					signal: controller.signal,
+				},
+			});
 		}).rejects.toThrow(/aborted/i);
 	});
+
+	// TODO: Remove once the `signal` parameter is removed in favor of
+	// `fetchOptions.signal`.
+	it.concurrent(
+		`${description} (using deprecated \`signal\` param)`,
+		async (ctx) => {
+			const controller = new AbortController();
+			controller.abort();
+
+			mockPrismicRestAPIV2({ ctx });
+
+			const client = createTestClient();
+
+			await expect(async () => {
+				await args.run(client, {
+					signal: controller.signal,
+				});
+			}).rejects.toThrow(/aborted/i);
+		},
+	);
 };

--- a/test/__testutils__/testFetchOptions.ts
+++ b/test/__testutils__/testFetchOptions.ts
@@ -1,0 +1,98 @@
+import * as prismic from "../../src";
+import { createTestClient } from "./createClient";
+import { mockPrismicRestAPIV2 } from "./mockPrismicRestAPIV2";
+import fetch from "node-fetch";
+import { expect, it, vi } from "vitest";
+
+type TestFetchOptionsArgs = {
+	run: (
+		client: prismic.Client,
+		params?: Parameters<prismic.Client["get"]>[0],
+	) => Promise<unknown>;
+};
+
+export const testFetchOptions = (
+	description: string,
+	args: TestFetchOptionsArgs,
+): void => {
+	it.concurrent(`${description} (on client)`, async (ctx) => {
+		const abortController = new AbortController();
+
+		const fetchSpy = vi.fn(fetch);
+		const fetchOptions: prismic.RequestInitLike = {
+			cache: "no-store",
+			headers: {
+				foo: "bar",
+			},
+			signal: abortController.signal,
+		};
+
+		const repositoryResponse = ctx.mock.api.repository();
+		const masterRef = ctx.mock.api.ref({ isMasterRef: true });
+		const releaseRef = ctx.mock.api.ref({ isMasterRef: false });
+		releaseRef.id = "id"; // Referenced in ref-related tests.
+		releaseRef.label = "label"; // Referenced in ref-related tests.
+		repositoryResponse.refs = [masterRef, releaseRef];
+
+		mockPrismicRestAPIV2({
+			ctx,
+			repositoryResponse,
+			queryResponse: ctx.mock.api.query({
+				documents: [ctx.mock.value.document()],
+			}),
+		});
+
+		const client = createTestClient({
+			clientConfig: {
+				fetch: fetchSpy,
+				fetchOptions,
+			},
+		});
+
+		await args.run(client);
+
+		for (const [input, init] of fetchSpy.mock.calls) {
+			expect(init, input.toString()).toStrictEqual(fetchOptions);
+		}
+	});
+
+	it.concurrent(`${description} (on method)`, async (ctx) => {
+		const abortController = new AbortController();
+
+		const fetchSpy = vi.fn(fetch);
+		const fetchOptions: prismic.RequestInitLike = {
+			cache: "no-store",
+			headers: {
+				foo: "bar",
+			},
+			signal: abortController.signal,
+		};
+
+		const repositoryResponse = ctx.mock.api.repository();
+		const masterRef = ctx.mock.api.ref({ isMasterRef: true });
+		const releaseRef = ctx.mock.api.ref({ isMasterRef: false });
+		releaseRef.id = "id"; // Referenced in ref-related tests.
+		releaseRef.label = "label"; // Referenced in ref-related tests.
+		repositoryResponse.refs = [masterRef, releaseRef];
+
+		mockPrismicRestAPIV2({
+			ctx,
+			repositoryResponse,
+			queryResponse: ctx.mock.api.query({
+				documents: [ctx.mock.value.document()],
+			}),
+		});
+
+		const client = createTestClient({
+			clientConfig: {
+				fetch: fetchSpy,
+			},
+		});
+
+		await args.run(client, { fetchOptions });
+
+		for (const [input, init] of fetchSpy.mock.calls) {
+			expect(init, input.toString()).toStrictEqual(fetchOptions);
+		}
+	});
+};

--- a/test/client-dangerouslyGetAll.test.ts
+++ b/test/client-dangerouslyGetAll.test.ts
@@ -7,6 +7,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 
 import { GET_ALL_QUERY_DELAY } from "../src/client";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 /**
  * Tolerance in number of milliseconds for the duration of a simulated network
@@ -178,6 +179,10 @@ it("does not throttle single page queries", async (ctx) => {
 	).toBe(true);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.dangerouslyGetAll(params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.dangerouslyGetAll({ signal }),
+	run: (client, params) => client.dangerouslyGetAll(params),
 });

--- a/test/client-get.test.ts
+++ b/test/client-get.test.ts
@@ -1,5 +1,6 @@
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("resolves a query", {
 	run: (client) => client.get(),
@@ -52,6 +53,10 @@ testGetMethod("merges params and default params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.get(params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.get({ signal }),
+	run: (client, params) => client.get(params),
 });

--- a/test/client-getAllByEveryTag.test.ts
+++ b/test/client-getAllByEveryTag.test.ts
@@ -1,5 +1,6 @@
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by every tag from paginated response", {
 	run: (client) => client.getAllByEveryTag(["foo", "bar"]),
@@ -23,6 +24,10 @@ testGetAllMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByEveryTag(["foo", "bar"], params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllByEveryTag(["foo", "bar"], { signal }),
+	run: (client, params) => client.getAllByEveryTag(["foo", "bar"], params),
 });

--- a/test/client-getAllByIDs.test.ts
+++ b/test/client-getAllByIDs.test.ts
@@ -1,5 +1,6 @@
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by IDs from paginated response", {
 	run: (client) => client.getAllByIDs(["id1", "id2"]),
@@ -23,6 +24,10 @@ testGetAllMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByIDs(["id1", "id2"], params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllByIDs(["id1", "id2"], { signal }),
+	run: (client, params) => client.getAllByIDs(["id1", "id2"], params),
 });

--- a/test/client-getAllBySomeTags.test.ts
+++ b/test/client-getAllBySomeTags.test.ts
@@ -1,5 +1,6 @@
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by some tags from paginated response", {
 	run: (client) => client.getAllBySomeTags(["foo", "bar"]),
@@ -23,6 +24,10 @@ testGetAllMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllBySomeTags(["foo", "bar"], params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllBySomeTags(["foo", "bar"], { signal }),
+	run: (client, params) => client.getAllBySomeTags(["foo", "bar"], params),
 });

--- a/test/client-getAllByTag.test.ts
+++ b/test/client-getAllByTag.test.ts
@@ -1,5 +1,6 @@
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by tag from paginated response", {
 	run: (client) => client.getAllByTag("tag"),
@@ -23,6 +24,10 @@ testGetAllMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByTag("tag", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllByTag("tag", { signal }),
+	run: (client, params) => client.getAllByTag("tag", params),
 });

--- a/test/client-getAllByType.test.ts
+++ b/test/client-getAllByType.test.ts
@@ -1,5 +1,6 @@
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by type from paginated response", {
 	run: (client) => client.getAllByType("type"),
@@ -23,6 +24,10 @@ testGetAllMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByType("tag", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getAllByType("tag", { signal }),
+	run: (client, params) => client.getAllByType("tag", params),
 });

--- a/test/client-getAllByUIDs.test.ts
+++ b/test/client-getAllByUIDs.test.ts
@@ -1,5 +1,6 @@
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetAllMethod("returns all documents by UIDs from paginated response", {
 	run: (client) => client.getAllByUIDs("type", ["uid1", "uid2"]),
@@ -29,7 +30,12 @@ testGetAllMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) =>
+		client.getAllByUIDs("type", ["uid1", "uid2"], params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) =>
-		client.getAllByUIDs("type", ["uid1", "uid2"], { signal }),
+	run: (client, params) =>
+		client.getAllByUIDs("type", ["uid1", "uid2"], params),
 });

--- a/test/client-getByEveryTag.test.ts
+++ b/test/client-getByEveryTag.test.ts
@@ -1,5 +1,6 @@
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by tag", {
 	run: (client) => client.getByEveryTag(["foo", "bar"]),
@@ -23,6 +24,10 @@ testGetMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByEveryTag(["foo", "bar"], params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByEveryTag(["foo", "bar"], { signal }),
+	run: (client, params) => client.getByEveryTag(["foo", "bar"], params),
 });

--- a/test/client-getByID.test.ts
+++ b/test/client-getByID.test.ts
@@ -1,5 +1,6 @@
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetFirstMethod("queries for document by ID", {
 	run: (client) => client.getByID("id"),
@@ -23,6 +24,10 @@ testGetFirstMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByID("id", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByID("id", { signal }),
+	run: (client, params) => client.getByID("id", params),
 });

--- a/test/client-getByIDs.test.ts
+++ b/test/client-getByIDs.test.ts
@@ -1,5 +1,6 @@
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by IDs", {
 	run: (client) => client.getByIDs(["id1", "id2"]),
@@ -23,6 +24,10 @@ testGetMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByIDs(["id1", "id2"], params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByIDs(["id1", "id2"], { signal }),
+	run: (client, params) => client.getByIDs(["id1", "id2"], params),
 });

--- a/test/client-getBySomeTags.test.ts
+++ b/test/client-getBySomeTags.test.ts
@@ -1,5 +1,6 @@
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by some tags", {
 	run: (client) => client.getBySomeTags(["foo", "bar"]),
@@ -23,6 +24,10 @@ testGetMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getBySomeTags(["foo", "bar"], params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getBySomeTags(["foo", "bar"], { signal }),
+	run: (client, params) => client.getBySomeTags(["foo", "bar"], params),
 });

--- a/test/client-getByTag.test.ts
+++ b/test/client-getByTag.test.ts
@@ -1,5 +1,6 @@
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by tag", {
 	run: (client) => client.getByTag("tag"),
@@ -23,6 +24,10 @@ testGetMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByTag("tag", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByTag("tag", { signal }),
+	run: (client, params) => client.getByTag("tag", params),
 });

--- a/test/client-getByType.test.ts
+++ b/test/client-getByType.test.ts
@@ -1,5 +1,6 @@
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by type", {
 	run: (client) => client.getByType("type"),
@@ -23,6 +24,10 @@ testGetMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByType("type", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByType("type", { signal }),
+	run: (client, params) => client.getByType("type", params),
 });

--- a/test/client-getByUID.test.ts
+++ b/test/client-getByUID.test.ts
@@ -1,5 +1,6 @@
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetFirstMethod("queries for document by UID", {
 	run: (client) => client.getByUID("type", "uid"),
@@ -23,6 +24,10 @@ testGetFirstMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByUID("type", "uid", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getByUID("type", "uid", { signal }),
+	run: (client, params) => client.getByUID("type", "uid", params),
 });

--- a/test/client-getByUIDs.test.ts
+++ b/test/client-getByUIDs.test.ts
@@ -1,5 +1,6 @@
 import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetMethod("queries for documents by UIDs", {
 	run: (client) => client.getByUIDs("type", ["uid1", "uid2"]),
@@ -29,7 +30,10 @@ testGetMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByUIDs("type", ["uid1", "uid2"], params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) =>
-		client.getByUIDs("type", ["uid1", "uid2"], { signal }),
+	run: (client, params) => client.getByUIDs("type", ["uid1", "uid2"], params),
 });

--- a/test/client-getFirst.test.ts
+++ b/test/client-getFirst.test.ts
@@ -8,6 +8,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { createTestClient } from "./__testutils__/createClient";
 
 import * as prismic from "../src";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetFirstMethod("returns the first document from a response", {
 	run: (client) => client.getFirst(),
@@ -92,6 +93,10 @@ it("throws if no documents were returned", async (ctx) => {
 	);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getFirst(params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getFirst({ signal }),
+	run: (client, params) => client.getFirst(params),
 });

--- a/test/client-getMasterRef.test.ts
+++ b/test/client-getMasterRef.test.ts
@@ -3,6 +3,7 @@ import { it, expect } from "vitest";
 import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns the master ref", async (ctx) => {
 	const masterRef = ctx.mock.api.ref({ isMasterRef: true });
@@ -21,6 +22,10 @@ it("returns the master ref", async (ctx) => {
 	expect(res).toStrictEqual(masterRef);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getMasterRef(params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getMasterRef({ signal }),
+	run: (client, params) => client.getMasterRef(params),
 });

--- a/test/client-getRefByID.test.ts
+++ b/test/client-getRefByID.test.ts
@@ -5,6 +5,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 
 import * as prismic from "../src";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns a ref by ID", async (ctx) => {
 	const ref1 = ctx.mock.api.ref({ isMasterRef: true });
@@ -37,6 +38,10 @@ it("throws if ref could not be found", async (ctx) => {
 	);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getRefByID("id", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getRefByID("id", { signal }),
+	run: (client, params) => client.getRefByID("id", params),
 });

--- a/test/client-getRefByLabel.test.ts
+++ b/test/client-getRefByLabel.test.ts
@@ -5,6 +5,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 
 import * as prismic from "../src";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns a ref by label", async (ctx) => {
 	const ref1 = ctx.mock.api.ref({ isMasterRef: true });
@@ -37,6 +38,10 @@ it("throws if ref could not be found", async (ctx) => {
 	);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getRefByLabel("label", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getRefByLabel("label", { signal }),
+	run: (client, params) => client.getRefByLabel("label", params),
 });

--- a/test/client-getRefs.test.ts
+++ b/test/client-getRefs.test.ts
@@ -3,6 +3,7 @@ import { it, expect } from "vitest";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { createTestClient } from "./__testutils__/createClient";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns all refs", async (ctx) => {
 	const repositoryResponse = ctx.mock.api.repository();
@@ -17,6 +18,10 @@ it("returns all refs", async (ctx) => {
 	expect(res).toStrictEqual(repositoryResponse.refs);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getRefs(params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getRefs({ signal }),
+	run: (client, params) => client.getRefs(params),
 });

--- a/test/client-getReleaseById.test.ts
+++ b/test/client-getReleaseById.test.ts
@@ -5,6 +5,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { createTestClient } from "./__testutils__/createClient";
 
 import * as prismic from "../src";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns a Release by ID", async (ctx) => {
 	const ref1 = ctx.mock.api.ref({ isMasterRef: true });
@@ -35,6 +36,10 @@ it("throws if Release could not be found", async (ctx) => {
 	).rejects.toThrowError(prismic.PrismicError);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getReleaseByID("id", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getReleaseByID("id", { signal }),
+	run: (client, params) => client.getReleaseByID("id", params),
 });

--- a/test/client-getReleaseByLabel.test.ts
+++ b/test/client-getReleaseByLabel.test.ts
@@ -5,6 +5,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { createTestClient } from "./__testutils__/createClient";
 
 import * as prismic from "../src";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns a Release by label", async (ctx) => {
 	const ref1 = ctx.mock.api.ref({ isMasterRef: true });
@@ -35,6 +36,10 @@ it("throws if Release could not be found", async (ctx) => {
 	).rejects.toThrowError(prismic.PrismicError);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getReleaseByLabel("label", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getReleaseByLabel("label", { signal }),
+	run: (client, params) => client.getReleaseByLabel("label", params),
 });

--- a/test/client-getReleases.test.ts
+++ b/test/client-getReleases.test.ts
@@ -3,6 +3,7 @@ import { it, expect } from "vitest";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { createTestClient } from "./__testutils__/createClient";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns all Releases", async (ctx) => {
 	const repositoryResponse = ctx.mock.api.repository();
@@ -19,6 +20,10 @@ it("returns all Releases", async (ctx) => {
 	);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getReleases(params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getReleases({ signal }),
+	run: (client, params) => client.getReleases(params),
 });

--- a/test/client-getRepository.test.ts
+++ b/test/client-getRepository.test.ts
@@ -5,6 +5,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { createTestClient } from "./__testutils__/createClient";
 
 import * as prismic from "../src";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns repository metadata", async (ctx) => {
 	const repositoryResponse = ctx.mock.api.repository();
@@ -38,6 +39,10 @@ it("includes access token if configured", async (ctx) => {
 	expect(res).toStrictEqual(repositoryResponse);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getRepository(params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getRepository({ signal }),
+	run: (client, params) => client.getRepository(params),
 });

--- a/test/client-getSingle.test.ts
+++ b/test/client-getSingle.test.ts
@@ -1,5 +1,6 @@
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 testGetFirstMethod("queries for singleton document", {
 	run: (client) => client.getSingle("type"),
@@ -23,6 +24,10 @@ testGetFirstMethod("includes params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getSingle("type", params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getSingle("type", { signal }),
+	run: (client, params) => client.getSingle("type", params),
 });

--- a/test/client-getTags.test.ts
+++ b/test/client-getTags.test.ts
@@ -4,6 +4,7 @@ import * as msw from "msw";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { createTestClient } from "./__testutils__/createClient";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 it("returns all tags", async (ctx) => {
 	const repositoryResponse = ctx.mock.api.repository();
@@ -79,6 +80,10 @@ it("sends access token if form endpoint is used", async (ctx) => {
 	expect(res).toStrictEqual(tagsResponse);
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getTags(params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.getTags({ signal }),
+	run: (client, params) => client.getTags(params),
 });

--- a/test/client-query.test.ts
+++ b/test/client-query.test.ts
@@ -2,6 +2,7 @@ import { testGetMethod } from "./__testutils__/testAnyGetMethod";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
 
 import * as prismic from "../src";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 const predicate = prismic.predicate.at("document.type", "page");
 const q = `[${predicate}]`;
@@ -63,6 +64,10 @@ testGetMethod("merges params and default params if provided", {
 	},
 });
 
+testFetchOptions("supports fetch options", {
+	run: (client, params) => client.query(predicate, params),
+});
+
 testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) => client.query(predicate, { signal }),
+	run: (client, params) => client.query(predicate, params),
 });

--- a/test/client-resolvePreviewUrl.test.ts
+++ b/test/client-resolvePreviewUrl.test.ts
@@ -5,6 +5,7 @@ import * as prismicM from "@prismicio/mock";
 import { createTestClient } from "./__testutils__/createClient";
 import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2";
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod";
+import { testFetchOptions } from "./__testutils__/testFetchOptions";
 
 const previewToken = "previewToken";
 
@@ -220,10 +221,20 @@ it("returns defaultURL if resolved URL is not a string", async (ctx) => {
 	expect(res).toBe(defaultURL);
 });
 
-testAbortableMethod("is abortable with an AbortController", {
-	run: (client, signal) =>
+testFetchOptions("supports fetch options", {
+	run: (client, params) =>
 		client.resolvePreviewURL({
-			signal,
+			...params,
+			defaultURL: "defaultURL",
+			documentID: "foo",
+			previewToken,
+		}),
+});
+
+testAbortableMethod("is abortable with an AbortController", {
+	run: (client, params) =>
+		client.resolvePreviewURL({
+			...params,
 			defaultURL: "defaultURL",
 			documentID: "foo",
 			previewToken,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

> **Note**: This PR backports #289 from v7 to v6. It is being backported to support existing Next.js projects that want to upgrade to App Router, but can't yet upgrade `@prismicio/client` to v7.
>
> The following description is copied from #289, originally written for v7.

This PR adds a new `fetchOptions` parameter to `createClient()` and all client methods that make network requests.

The parameter allows for customizing how `fetch()` is called.

```typescript
// Set `fetch()` options for every request.
const client = createClient("example-prismic-repo", {
  fetchOptions: {
    cache: "force-cache",
  },
});

// Set or override `fetch()` options for individual queries.
const page = await client.getByUID("page", "home", {
  fetchOptions: {
    cache: "no-store",
  },
});
```

### Supported options

The TypeScript types support a subset of the global `RequestInit` type:

- [`headers`](https://developer.mozilla.org/en-US/docs/Web/API/Request/headers) (only plain objects are supported)
- [`cache`](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache)
- [`signal`](https://developer.mozilla.org/en-US/docs/Web/API/Request/signal)

These three parameters have known real-world use cases, while others, like [`credentials`](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials), currently do not.

If we learn that other parameters are needed, we can add support for them in the future.

### Adding support for project-specific options

`@prismicio/client`'s type for `fetchOptions` can be augmented on a per-project basis using [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).

This is useful if a project needs to add support for a `RequestInit` property that is not supported by default. It is also useful if projects have project-specific `RequestInit` features that need to be added, like [Next.js' `next` parameter](https://nextjs.org/docs/app/api-reference/functions/fetch#optionsnextrevalidate).

```typescript
// Adds `credentials` support.
declare module "@prismicio/client" {
  interface RequestInitLike {
    credentials?: RequestInit["credentials"];
  }
}

const client = createClient("example-prismic-repo", {
  fetchOptions: {
    credentials: "same-origin",
  },
});
```

### Deprecating `signal` parameter in favor of `fetchOptions.signal`

The `signal` parameter has been replaced by the more apt `fetchOptions.signal`.

```typescript
const controller = new AbortSignal();
const client = createClient("example-prismic-repo");

// New
await client.getByUID("page", "home", {
  fetchOptions: {
    signal: controller.signal,
  },
});

// Old
await client.getByUID("page", "home", {
  signal: controller.signal,
});
```

`signal` will continue to be supported, but has been marked as deprecated. Please migrate to `fetchOptions.signal`.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐈‍⬛
