### PR TITLE
fix: update Prismic terms to use the latest language style

### DIFF
--- a/src/buildQueryURL.ts
+++ b/src/buildQueryURL.ts
@@ -184,8 +184,8 @@ export interface QueryParams {
 
 	/**
 	 * The `brokenRoute` option allows you to define the route populated in the
-	 * `url` property for broken Link or Content Relationship fields. A broken
-	 * link is a Link or Content Relationship field whose linked document has been
+	 * `url` property for broken link or content relationship fields. A broken
+	 * link is a link or content relationship field whose linked document has been
 	 * unpublished or deleted.
 	 *
 	 * {@link https://prismic.io/docs/route-resolver}

--- a/src/buildQueryURL.ts
+++ b/src/buildQueryURL.ts
@@ -205,7 +205,7 @@ type BuildQueryURLParams = {
 	ref: string;
 
 	/**
-	 * Ref used to populate Integration Fields with the latest content.
+	 * Ref used to populate integration fields with the latest content.
 	 *
 	 * {@link https://prismic.io/docs/integration-fields}
 	 */

--- a/src/buildQueryURL.ts
+++ b/src/buildQueryURL.ts
@@ -53,7 +53,7 @@ export interface Ordering {
  */
 export interface Route {
 	/**
-	 * The Custom Type of the document.
+	 * The custom type of the document.
 	 */
 	type: string;
 

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -234,7 +234,7 @@ export type ClientConfig = {
 	ref?: RefStringOrThunk;
 
 	/**
-	 * A list of Route Resolver objects that define how a document's `url` field
+	 * A list of Route Resolver objects that define how a document's `url` property
 	 * is resolved.
 	 *
 	 * {@link https://prismic.io/docs/route-resolver}
@@ -243,8 +243,8 @@ export type ClientConfig = {
 
 	/**
 	 * The `brokenRoute` option allows you to define the route populated in the
-	 * `url` property for broken Link or Content Relationship fields. A broken
-	 * link is a Link or Content Relationship field whose linked document has been
+	 * `url` property for broken link or content relationship fields. A broken
+	 * link is a link or content relationship field whose linked document has been
 	 * unpublished or deleted.
 	 *
 	 * {@link https://prismic.io/docs/route-resolver}
@@ -424,8 +424,8 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 
 	/**
 	 * The `brokenRoute` option allows you to define the route populated in the
-	 * `url` property for broken Link or Content Relationship fields. A broken
-	 * link is a Link or Content Relationship field whose linked document has been
+	 * `url` property for broken link or content relationship fields. A broken
+	 * link is a link or content relationship field whose linked document has been
 	 * unpublished or deleted.
 	 *
 	 * {@link https://prismic.io/docs/route-resolver}
@@ -735,7 +735,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * A document's UID is different from its ID. An ID is automatically generated
 	 * for all documents and is made available on its `id` property. A UID is
 	 * provided in the Prismic editor and is unique among all documents of its
-	 * Custom Type.
+	 * custom type.
 	 * @example
 	 *
 	 * ```ts
@@ -765,7 +765,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * A document's UID is different from its ID. An ID is automatically generated
 	 * for all documents and is made available on its `id` property. A UID is
 	 * provided in the Prismic editor and is unique among all documents of its
-	 * Custom Type.
+	 * custom type.
 	 * @example
 	 *
 	 * ```ts
@@ -801,7 +801,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * A document's UID is different from its ID. An ID is automatically generated
 	 * for all documents and is made available on its `id` property. A UID is
 	 * provided in the Prismic editor and is unique among all documents of its
-	 * Custom Type.
+	 * custom type.
 	 * @example
 	 *
 	 * ```ts
@@ -828,13 +828,13 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 
 	/**
 	 * Queries a document from the Prismic repository with a specific UID and
-	 * Custom Type.
+	 * custom type.
 	 *
 	 * @remarks
 	 * A document's UID is different from its ID. An ID is automatically generated
 	 * for all documents and is made available on its `id` property. A UID is
 	 * provided in the Prismic editor and is unique among all documents of its
-	 * Custom Type.
+	 * custom type.
 	 * @example
 	 *
 	 * ```ts
@@ -842,7 +842,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * ```
 	 *
 	 * @typeParam TDocument - Type of the Prismic document returned.
-	 * @param documentType - The API ID of the document's Custom Type.
+	 * @param documentType - The API ID of the document's custom type.
 	 * @param uid - UID of the document.
 	 * @param params - Parameters to filter, sort, and paginate the results.
 	 *
@@ -873,7 +873,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * A document's UID is different from its ID. An ID is automatically generated
 	 * for all documents and is made available on its `id` property. A UID is
 	 * provided in the Prismic editor and is unique among all documents of its
-	 * Custom Type.
+	 * custom type.
 	 * @example
 	 *
 	 * ```ts
@@ -884,7 +884,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * ```
 	 *
 	 * @typeParam TDocument - Type of the Prismic document returned.
-	 * @param documentType - The API ID of the document's Custom Type.
+	 * @param documentType - The API ID of the document's custom type.
 	 * @param uids - A list of document UIDs.
 	 * @param params - Parameters to filter, sort, and paginate the results.
 	 *
@@ -909,7 +909,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 
 	/**
 	 * Queries all documents from the Prismic repository with specific UIDs and
-	 * Custom Type.
+	 * custom type.
 	 *
 	 * This method may make multiple network requests to query all matching
 	 * content.
@@ -918,7 +918,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * A document's UID is different from its ID. An ID is automatically generated
 	 * for all documents and is made available on its `id` property. A UID is
 	 * provided in the Prismic editor and is unique among all documents of its
-	 * Custom Type.
+	 * custom type.
 	 * @example
 	 *
 	 * ```ts
@@ -929,7 +929,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * ```
 	 *
 	 * @typeParam TDocument - Type of Prismic documents returned.
-	 * @param documentType - The API ID of the document's Custom Type.
+	 * @param documentType - The API ID of the document's custom type.
 	 * @param uids - A list of document UIDs.
 	 * @param params - Parameters to filter, sort, and paginate the results.
 	 *
@@ -955,12 +955,12 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 
 	/**
 	 * Queries a singleton document from the Prismic repository for a specific
-	 * Custom Type.
+	 * custom type.
 	 *
 	 * @remarks
 	 * A singleton document is one that is configured in Prismic to only allow one
 	 * instance. For example, a repository may be configured to contain just one
-	 * Settings document. This is in contrast to a repeatable Custom Type which
+	 * Settings document. This is in contrast to a repeatable custom type which
 	 * allows multiple instances of itself.
 	 * @example
 	 *
@@ -969,10 +969,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * ```
 	 *
 	 * @typeParam TDocument - Type of the Prismic document returned.
-	 * @param documentType - The API ID of the singleton Custom Type.
+	 * @param documentType - The API ID of the singleton custom type.
 	 * @param params - Parameters to filter, sort, and paginate the results.
 	 *
-	 * @returns The singleton document for the Custom Type, if a matching document
+	 * @returns The singleton document for the custom type, if a matching document
 	 *   exists.
 	 */
 	async getSingle<
@@ -988,10 +988,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	}
 
 	/**
-	 * Queries documents from the Prismic repository for a specific Custom Type.
+	 * Queries documents from the Prismic repository for a specific custom type.
 	 *
 	 * Use `getAllByType` instead if you need to query all documents for a
-	 * specific Custom Type.
+	 * specific custom type.
 	 *
 	 * @example
 	 *
@@ -1000,10 +1000,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * ```
 	 *
 	 * @typeParam TDocument - Type of Prismic documents returned.
-	 * @param documentType - The API ID of the Custom Type.
+	 * @param documentType - The API ID of the custom type.
 	 * @param params - Parameters to filter, sort, and paginate the results.
 	 *
-	 * @returns A paginated response containing documents of the Custom Type.
+	 * @returns A paginated response containing documents of the custom type.
 	 */
 	async getByType<
 		TDocument extends TDocuments,
@@ -1031,10 +1031,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 	 * ```
 	 *
 	 * @typeParam TDocument - Type of Prismic documents returned.
-	 * @param documentType - The API ID of the Custom Type.
+	 * @param documentType - The API ID of the custom type.
 	 * @param params - Parameters to filter, sort, and paginate the results.
 	 *
-	 * @returns A list of all documents of the Custom Type.
+	 * @returns A list of all documents of the custom type.
 	 */
 	async getAllByType<
 		TDocument extends TDocuments,

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -177,7 +177,7 @@ export const filter = {
 	 * The `geopoint.near` filter checks that the value in the path is within
 	 * the radius of the given coordinates.
 	 *
-	 * This filter will only work for a GeoPoint field.
+	 * This filter will only work for a geopoint field.
 	 *
 	 * {@link https://prismic.io/docs/rest-api-technical-reference#geopointnear}
 	 */

--- a/src/helpers/asDate.ts
+++ b/src/helpers/asDate.ts
@@ -9,9 +9,9 @@ type AsDateReturnType<
 > = Field extends DateField<"filled"> | TimestampField<"filled"> ? Date : null;
 
 /**
- * Transforms a Date or Timestamp field into a JavaScript Date object
+ * Transforms a date or timestamp field into a JavaScript Date object
  *
- * @param dateOrTimestampField - A Date or Timestamp field from Prismic
+ * @param dateOrTimestampField - A date or timestamp field from Prismic
  *
  * @returns A Date object, null if provided date is falsy
  * @see Templating date field from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#date-and-timestamp}

--- a/src/helpers/asHTML.ts
+++ b/src/helpers/asHTML.ts
@@ -22,13 +22,13 @@ import type { RichTextField } from "../types/value/richText";
 import { LinkResolverFunction } from "./asLink";
 
 /**
- * Serializes a node from a Rich Text or Title field with a function to HTML.
+ * Serializes a node from a rich text or title field with a function to HTML.
  *
  * Unlike a typical `@prismicio/richtext` function serializer, this serializer
  * converts the `children` argument to a single string rather than an array of
  * strings.
  *
- * @see Templating Rich Text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
+ * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
  */
 export type HTMLRichTextFunctionSerializer = (
 	type: Parameters<RichTextFunctionSerializer<string>>[0],
@@ -39,13 +39,13 @@ export type HTMLRichTextFunctionSerializer = (
 ) => string | null | undefined;
 
 /**
- * Serializes a node from a Rich Text or Title field with a map to HTML
+ * Serializes a node from a rich text or title field with a map to HTML
  *
  * Unlike a typical `@prismicio/richtext` map serializer, this serializer
  * converts the `children` property to a single string rather than an array of
  * strings.
  *
- * @see Templating Rich Text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
+ * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
  */
 export type HTMLRichTextMapSerializer = {
 	[P in keyof RichTextMapSerializer<string>]: (payload: {
@@ -63,7 +63,7 @@ export type HTMLRichTextMapSerializer = {
  * A {@link RichTextMapSerializerFunction} type specifically for
  * {@link HTMLRichTextMapSerializer}.
  *
- * @typeParam BlockName - The serializer's Rich Text block type.
+ * @typeParam BlockName - The serializer's rich text block type.
  */
 type HTMLRichTextMapSerializerFunction<
 	BlockType extends keyof RichTextMapSerializer<string>,
@@ -106,17 +106,17 @@ type ExtractTextTypeGeneric<T> = T extends RichTextMapSerializerFunction<
 	: never;
 
 /**
- * Serializes a node from a Rich Text or Title field with a map or a function to HTML
+ * Serializes a node from a rich text or title field with a map or a function to HTML
  *
  * @see {@link HTMLRichTextMapSerializer} and {@link HTMLRichTextFunctionSerializer}
- * @see Templating Rich Text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
+ * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
  */
 export type HTMLRichTextSerializer =
 	| HTMLRichTextMapSerializer
 	| HTMLRichTextFunctionSerializer;
 
 /**
- * Creates a default HTML Rich Text Serializer with a given Link Resolver providing
+ * Creates a default HTML rich text Serializer with a given Link Resolver providing
  * sensible and safe defaults for every node type
  *
  * @internal
@@ -211,7 +211,7 @@ type AsHTMLConfig = {
 	linkResolver?: LinkResolverFunction | null;
 
 	/**
-	 * An optional Rich Text Serializer, unhandled cases will fallback to the default serializer
+	 * An optional rich text Serializer, unhandled cases will fallback to the default serializer
 	 */
 	htmlRichTextSerializer?: HTMLRichTextSerializer | null;
 };
@@ -234,13 +234,13 @@ type AsHTMLReturnType<Field extends RichTextField | null | undefined> =
 // TODO: Remove overload when we remove support for deprecated tuple-style configuration.
 export const asHTML: {
 	/**
-	 * Serializes a Rich Text or Title field to an HTML string.
+	 * Serializes a rich text or title field to an HTML string.
 	 *
-	 * @param richTextField - A Rich Text or Title field from Prismic
+	 * @param richTextField - A rich text or title field from Prismic
 	 * @param config - Configuration that determines the output of `asHTML()`
 	 *
-	 * @returns HTML equivalent of the provided Rich Text or Title field
-	 * @see Templating Rich Text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
+	 * @returns HTML equivalent of the provided rich text or title field
+	 * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
 	 */
 	<Field extends RichTextField | null | undefined>(
 		richTextField: Field,
@@ -248,16 +248,16 @@ export const asHTML: {
 	): AsHTMLReturnType<Field>;
 
 	/**
-	 * Serializes a Rich Text or Title field to an HTML string.
+	 * Serializes a rich text or title field to an HTML string.
 	 *
-	 * @param richTextField - A Rich Text or Title field from Prismic
+	 * @param richTextField - A rich text or title field from Prismic
 	 * @param linkResolver - An optional link resolver function to resolve links,
 	 *   without it you're expected to use the `routes` options from the API
-	 * @param htmlRichTextSerializer - An optional Rich Text Serializer, unhandled cases will fallback
+	 * @param htmlRichTextSerializer - An optional rich text Serializer, unhandled cases will fallback
 	 *   to the default serializer
 	 *
-	 * @returns HTML equivalent of the provided Rich Text or Title field
-	 * @see Templating Rich Text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
+	 * @returns HTML equivalent of the provided rich text or title field
+	 * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
 	 *
 	 * @deprecated Use object-style configuration instead.
 	 *

--- a/src/helpers/asImagePixelDensitySrcSet.ts
+++ b/src/helpers/asImagePixelDensitySrcSet.ts
@@ -30,12 +30,12 @@ type AsImagePixelDensitySrcSetReturnType<
 > = Field extends ImageFieldImage<"filled">
 	? {
 			/**
-			 * The Image field's image URL with Imgix URL parameters (if given).
+			 * The image field's image URL with Imgix URL parameters (if given).
 			 */
 			src: string;
 
 			/**
-			 * A pixel-densitye-based `srcset` attribute value for the Image field's
+			 * A pixel-densitye-based `srcset` attribute value for the image field's
 			 * image with Imgix URL parameters (if given).
 			 */
 			srcset: string;
@@ -43,7 +43,7 @@ type AsImagePixelDensitySrcSetReturnType<
 	: null;
 
 /**
- * Creates a pixel-density-based `srcset` from an Image field with optional
+ * Creates a pixel-density-based `srcset` from an image field with optional
  * image transformations (via Imgix URL parameters).
  *
  * If a `pixelDensities` parameter is not given, the following pixel densities
@@ -68,8 +68,8 @@ type AsImagePixelDensitySrcSetReturnType<
  * @param config - An object of Imgix URL API parameters. The `pixelDensities`
  *   parameter defines the resulting `srcset` widths.
  *
- * @returns A `srcset` attribute value for the Image field with Imgix URL
- *   parameters (if given). If the Image field is empty, `null` is returned.
+ * @returns A `srcset` attribute value for the image field with Imgix URL
+ *   parameters (if given). If the image field is empty, `null` is returned.
  * @see Imgix URL parameters reference: https://docs.imgix.com/apis/rendering
  */
 export const asImagePixelDensitySrcSet = <

--- a/src/helpers/asImageSrc.ts
+++ b/src/helpers/asImageSrc.ts
@@ -11,7 +11,7 @@ type AsImageSrcReturnType<Field extends ImageFieldImage | null | undefined> =
 	Field extends ImageFieldImage<"filled"> ? string : null;
 
 /**
- * Returns the URL of an Image field with optional image transformations (via
+ * Returns the URL of an image field with optional image transformations (via
  * Imgix URL parameters).
  *
  * @example
@@ -25,8 +25,8 @@ type AsImageSrcReturnType<Field extends ImageFieldImage | null | undefined> =
  *   an image URL.
  * @param config - An object of Imgix URL API parameters to transform the image.
  *
- * @returns The Image field's image URL with transformations applied (if given).
- *   If the Image field is empty, `null` is returned.
+ * @returns The image field's image URL with transformations applied (if given).
+ *   If the image field is empty, `null` is returned.
  * @see Imgix URL parameters reference: https://docs.imgix.com/apis/rendering
  */
 export const asImageSrc = <Field extends ImageFieldImage | null | undefined>(

--- a/src/helpers/asImageWidthSrcSet.ts
+++ b/src/helpers/asImageWidthSrcSet.ts
@@ -21,12 +21,12 @@ type AsImageWidthSrcSetReturnType<
 > = Field extends ImageFieldImage<"filled">
 	? {
 			/**
-			 * The Image field's image URL with Imgix URL parameters (if given).
+			 * The image field's image URL with Imgix URL parameters (if given).
 			 */
 			src: string;
 
 			/**
-			 * A width-based `srcset` attribute value for the Image field's image with
+			 * A width-based `srcset` attribute value for the image field's image with
 			 * Imgix URL parameters (if given).
 			 */
 			srcset: string;
@@ -41,13 +41,13 @@ type AsImageWidthSrcSetConfig = Omit<BuildWidthSrcSetParams, "widths"> & {
 };
 
 /**
- * Creates a width-based `srcset` from an Image field with optional image
+ * Creates a width-based `srcset` from an image field with optional image
  * transformations (via Imgix URL parameters).
  *
  * If a `widths` parameter is not given, the following widths will be used by
  * default: 640, 750, 828, 1080, 1200, 1920, 2048, 3840.
  *
- * If the Image field contains responsive views, each responsive view can be
+ * If the image field contains responsive views, each responsive view can be
  * used as a width in the resulting `srcset` by passing `"thumbnails"` as the
  * `widths` parameter.
  *
@@ -72,8 +72,8 @@ type AsImageWidthSrcSetConfig = Omit<BuildWidthSrcSetParams, "widths"> & {
  *   defines the resulting `srcset` widths. Pass `"thumbnails"` to automatically
  *   use the field's responsive views.
  *
- * @returns A `srcset` attribute value for the Image field with Imgix URL
- *   parameters (if given). If the Image field is empty, `null` is returned.
+ * @returns A `srcset` attribute value for the image field with Imgix URL
+ *   parameters (if given). If the image field is empty, `null` is returned.
  * @see Imgix URL parameters reference: https://docs.imgix.com/apis/rendering
  */
 export const asImageWidthSrcSet = <

--- a/src/helpers/asLink.ts
+++ b/src/helpers/asLink.ts
@@ -6,14 +6,14 @@ import type { FilledLinkToMediaField } from "../types/value/linkToMedia";
 import { documentToLinkField } from "./documentToLinkField";
 
 /**
- * Resolves a Link to a Prismic document to a URL
+ * Resolves a link to a Prismic document to a URL
  *
- * @typeParam ReturnType - Return type of your link resolver function, useful if
+ * @typeParam ReturnType - Return type of your Link Resolver function, useful if
  *   you prefer to return a complex object
- * @param linkToDocumentField - A document Link Field to resolve
+ * @param linkToDocumentField - A document link field to resolve
  *
  * @returns Resolved URL
- * @see Prismic link resolver documentation: {@link https://prismic.io/docs/route-resolver#link-resolver}
+ * @see Prismic Link Resolver documentation: {@link https://prismic.io/docs/route-resolver#link-resolver}
  */
 export type LinkResolverFunction<ReturnType = string | null | undefined> = (
 	linkToDocumentField: FilledContentRelationshipField,
@@ -136,7 +136,7 @@ export const asLink: {
 		return null as AsLinkReturnType<LinkResolverFunctionReturnType, Field>;
 	}
 
-	// Converts document to Link Field if needed
+	// Converts document to link field if needed
 	const linkField =
 		// prettier-ignore
 		(

--- a/src/helpers/asLink.ts
+++ b/src/helpers/asLink.ts
@@ -62,15 +62,15 @@ export type AsLinkReturnType<
 // TODO: Remove overload when we remove support for deprecated tuple-style configuration.
 export const asLink: {
 	/**
-	 * Resolves any type of Link field or Prismic document to a URL.
+	 * Resolves any type of link field or Prismic document to a URL.
 	 *
 	 * @typeParam LinkResolverFunctionReturnType - Link Resolver function return
 	 *   type
 	 * @typeParam Field - Link field or Prismic document to resolve to a URL
-	 * @param linkFieldOrDocument - Any kind of Link field or a document to resolve
+	 * @param linkFieldOrDocument - Any kind of link field or a document to resolve
 	 * @param config - Configuration that determines the output of `asLink()`
 	 *
-	 * @returns Resolved URL or, if the provided Link field or document is empty, `null`
+	 * @returns Resolved URL or, if the provided link field or document is empty, `null`
 	 * @see Prismic Link Resolver documentation: {@link https://prismic.io/docs/route-resolver#link-resolver}
 	 * @see Prismic API `routes` options documentation: {@link https://prismic.io/docs/route-resolver}
 	 */
@@ -87,16 +87,16 @@ export const asLink: {
 	): AsLinkReturnType<LinkResolverFunctionReturnType, Field>;
 
 	/**
-	 * Resolves any type of Link field or Prismic document to a URL.
+	 * Resolves any type of link field or Prismic document to a URL.
 	 *
 	 * @typeParam LinkResolverFunctionReturnType - Link Resolver function return
 	 *   type
 	 * @typeParam Field - Link field or Prismic document to resolve to a URL
-	 * @param linkFieldOrDocument - Any kind of Link field or a document to resolve
+	 * @param linkFieldOrDocument - Any kind of link field or a document to resolve
 	 * @param linkResolver - An optional Link Resolver function. Without it, you are
 	 *   expected to use the `routes` options from the API
 	 *
-	 * @returns Resolved URL or, if the provided Link field or document is empty, `null`
+	 * @returns Resolved URL or, if the provided link field or document is empty, `null`
 	 * @see Prismic Link Resolver documentation: {@link https://prismic.io/docs/route-resolver#link-resolver}
 	 * @see Prismic API `routes` options documentation: {@link https://prismic.io/docs/route-resolver}
 	 *

--- a/src/helpers/asLinkAttrs.ts
+++ b/src/helpers/asLinkAttrs.ts
@@ -66,17 +66,17 @@ type AsLinkAttrsReturnType<
 	  };
 
 /**
- * Resolves any type of Link field or Prismic document to a set of link attributes. The attributes are designed to be passed to link HTML elements, like `<a>`.
+ * Resolves any type of link field or Prismic document to a set of link attributes. The attributes are designed to be passed to link HTML elements, like `<a>`.
  *
  * If a resolved URL is external (i.e. starts with a protocol like `https://`), `rel` is returned as `"noreferrer"`.
  *
  * @typeParam LinkResolverFunctionReturnType - Link Resolver function return
  *   type
  * @typeParam Field - Link field or Prismic document to resolve to link attributes
- * @param linkFieldOrDocument - Any kind of Link field or a document to resolve
+ * @param linkFieldOrDocument - Any kind of link field or a document to resolve
  * @param config - Configuration that determines the output of `asLinkAttrs()`
  *
- * @returns Resolved set of link attributes or, if the provided Link field or document is empty, and empty object
+ * @returns Resolved set of link attributes or, if the provided link field or document is empty, and empty object
  * @see Prismic Link Resolver documentation: {@link https://prismic.io/docs/route-resolver#link-resolver}
  * @see Prismic API `routes` options documentation: {@link https://prismic.io/docs/route-resolver}
  */

--- a/src/helpers/asText.ts
+++ b/src/helpers/asText.ts
@@ -28,13 +28,13 @@ type AsTextReturnType<Field extends RichTextField | null | undefined> =
 
 export const asText: {
 	/**
-	 * Serializes a Rich Text or Title field to a plain text string.
+	 * Serializes a rich text or title field to a plain text string.
 	 *
-	 * @param richTextField - A Rich Text or Title field from Prismic
+	 * @param richTextField - A rich text or title field from Prismic
 	 * @param config - Configuration that determines the output of `asText()`
 	 *
-	 * @returns Plain text equivalent of the provided Rich Text or Title field
-	 * @see Templating Rich Text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
+	 * @returns Plain text equivalent of the provided rich text or title field
+	 * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
 	 */
 	<Field extends RichTextField | null | undefined>(
 		richTextField: Field,
@@ -42,13 +42,13 @@ export const asText: {
 	): AsTextReturnType<Field>;
 
 	/**
-	 * Serializes a Rich Text or Title field to a plain text string.
+	 * Serializes a rich text or title field to a plain text string.
 	 *
-	 * @param richTextField - A Rich Text or Title field from Prismic
+	 * @param richTextField - A rich text or title field from Prismic
 	 * @param separator - Separator used to join each element, defaults to a space
 	 *
-	 * @returns Plain text equivalent of the provided Rich Text or Title field
-	 * @see Templating Rich Text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
+	 * @returns Plain text equivalent of the provided rich text or title field
+	 * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/template-content-vanilla-javascript#rich-text-and-title}
 	 *
 	 * @deprecated Use object-style configuration instead.
 	 *

--- a/src/helpers/documentToLinkField.ts
+++ b/src/helpers/documentToLinkField.ts
@@ -32,7 +32,7 @@ export const documentToLinkField = <
 		tags: prismicDocument.tags,
 		lang: prismicDocument.lang,
 		url: prismicDocument.url == null ? undefined : prismicDocument.url,
-		slug: prismicDocument.slugs?.[0], // Slug field is not available with GraphQl
+		slug: prismicDocument.slugs?.[0], // Slug field is not available with GraphQL
 		// The REST API does not include a `data` property if the data
 		// object is empty.
 		//

--- a/src/helpers/isFilled.ts
+++ b/src/helpers/isFilled.ts
@@ -121,7 +121,7 @@ export const link = <
 /**
  * Determines if a link to media field is filled.
  *
- * @param field - Link to Media field to check.
+ * @param field - Link to media field to check.
  *
  * @returns `true` if `field` is filled, `false` otherwise.
  */

--- a/src/helpers/isFilled.ts
+++ b/src/helpers/isFilled.ts
@@ -5,7 +5,7 @@ import type { AnyOEmbed, EmbedField } from "../types/value/embed";
 import type { GeoPointField } from "../types/value/geoPoint";
 import type { GroupField } from "../types/value/group";
 import type { ImageField, ImageFieldImage } from "../types/value/image";
-import type { IntegrationFields } from "../types/value/integrationFields";
+import type { IntegrationField } from "../types/value/integration";
 import type { KeyTextField } from "../types/value/keyText";
 import type { LinkField } from "../types/value/link";
 import type { LinkToMediaField } from "../types/value/linkToMedia";
@@ -44,9 +44,9 @@ const isNonEmptyArray = <T>(input: T[]): input is [T, ...T[]] => {
 };
 
 /**
- * Determines if a Rich Text field is filled.
+ * Determines if a rich text field is filled.
  *
- * @param field - Rich Text field to check.
+ * @param field - rich text field to check.
  *
  * @returns `true` if `field` is filled, `false` otherwise.
  */
@@ -63,7 +63,7 @@ export const richText = (
 };
 
 /**
- * Determines if a Title field is filled.
+ * Determines if a title field is filled.
  *
  * @param field - Title field to check.
  *
@@ -87,7 +87,7 @@ export const imageThumbnail = (
 };
 
 /**
- * Determines if an Image field is filled.
+ * Determines if an image field is filled.
  *
  * @param field - Image field to check.
  *
@@ -100,7 +100,7 @@ export const image = imageThumbnail as <
 ) => field is ImageField<ThumbnailNames, "filled">;
 
 /**
- * Determines if a Link field is filled.
+ * Determines if a link field is filled.
  *
  * @param field - Link field to check.
  *
@@ -119,7 +119,7 @@ export const link = <
 };
 
 /**
- * Determines if a Link to Media field is filled.
+ * Determines if a link to media field is filled.
  *
  * @param field - Link to Media field to check.
  *
@@ -130,7 +130,7 @@ export const linkToMedia = link as (
 ) => field is LinkToMediaField<"filled">;
 
 /**
- * Determines if a Content Relationship field is filled.
+ * Determines if a content relationship field is filled.
  *
  * @param field - Content Relationship field to check.
  *
@@ -155,7 +155,7 @@ export const contentRelationship = link as <
 >;
 
 /**
- * Determines if a Date field is filled.
+ * Determines if a date field is filled.
  *
  * @param field - Date field to check.
  *
@@ -166,7 +166,7 @@ export const date = isNonNullish as (
 ) => field is DateField<"filled">;
 
 /**
- * Determines if a Timestamp field is filled.
+ * Determines if a timestamp field is filled.
  *
  * @param field - Timestamp field to check.
  *
@@ -177,7 +177,7 @@ export const timestamp = isNonNullish as (
 ) => field is TimestampField<"filled">;
 
 /**
- * Determines if a Color field is filled.
+ * Determines if a color field is filled.
  *
  * @param field - Color field to check.
  *
@@ -188,7 +188,7 @@ export const color = isNonNullish as (
 ) => field is ColorField<"filled">;
 
 /**
- * Determines if a Number field is filled.
+ * Determines if a number field is filled.
  *
  * @param field - Number field to check.
  *
@@ -199,7 +199,7 @@ export const number = isNonNullish as (
 ) => field is NumberField<"filled">;
 
 /**
- * Determines if a Key Text field is filled.
+ * Determines if a key text field is filled.
  *
  * @param field - Key Text field to check.
  *
@@ -212,7 +212,7 @@ export const keyText = (
 };
 
 /**
- * Determines if a Select field is filled.
+ * Determines if a select field is filled.
  *
  * @param field - Select field to check.
  *
@@ -223,7 +223,7 @@ export const select = isNonNullish as <Enum extends string>(
 ) => field is SelectField<Enum, "filled">;
 
 /**
- * Determines if an Embed field is filled.
+ * Determines if an embed field is filled.
  *
  * @param field - Embed field to check.
  *
@@ -236,7 +236,7 @@ export const embed = <Field extends EmbedField<AnyOEmbed>>(
 };
 
 /**
- * Determines if a GeoPoint field is filled.
+ * Determines if a geopoint field is filled.
  *
  * @param field - GeoPoint field to check.
  *
@@ -249,17 +249,22 @@ export const geoPoint = (
 };
 
 /**
- * Determines if an Integration Fields field is filled.
+ * Determines if an integration field is filled.
  *
- * @param field - Integration Fields field to check.
+ * @param field - Integration field to check.
  *
  * @returns `true` if `field` is filled, `false` otherwise.
  */
-export const integrationFields = isNonNullish as <
+export const integrationField = isNonNullish as <
 	Data extends Record<string, unknown>,
 >(
-	field: IntegrationFields<Data> | null | undefined,
-) => field is IntegrationFields<Data, "filled">;
+	field: IntegrationField<Data> | null | undefined,
+) => field is IntegrationField<Data, "filled">;
+/**
+ * @deprecated Renamed to `integrationField`.
+ */
+// TODO: Remove when we remove support for deprecated `integrationFields` export.
+export const integrationFields = integrationField;
 
 /**
  * Determines if a Group has at least one item.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-// Use for deprecations.
+// Imports are used for deprecations.
+import type { CustomTypeModelIntegrationField } from "./types/model/integration";
+import type { IntegrationField } from "./types/value/integration";
+
 import type {
 	HTMLRichTextFunctionSerializer,
 	HTMLRichTextMapSerializer,
@@ -196,7 +199,12 @@ export type { SelectField } from "./types/value/select";
 export type { TimestampField } from "./types/value/timestamp";
 export type { GeoPointField } from "./types/value/geoPoint";
 
-export type { IntegrationFields } from "./types/value/integrationFields";
+/**
+ * @deprecated Renamed to `IntegrationField`
+ */
+// TODO: Remove when we remove support for deprecated `IntegrationFields` export.
+type IntegrationFields = IntegrationField;
+export { IntegrationField, IntegrationFields };
 
 export type { GroupField } from "./types/value/group";
 
@@ -247,7 +255,15 @@ export type { CustomTypeModelSelectField } from "./types/model/select";
 export type { CustomTypeModelTimestampField } from "./types/model/timestamp";
 export type { CustomTypeModelGeoPointField } from "./types/model/geoPoint";
 
-export type { CustomTypeModelIntegrationFieldsField } from "./types/model/integrationFields";
+/**
+ * @deprecated Renamed to `CustomTypeModelIntegrationField`.
+ */
+// TODO: Remove when we remove support for deprecated `CustomTypeModelIntegrationField` export.
+type CustomTypeModelIntegrationFieldsField = CustomTypeModelIntegrationField;
+export {
+	CustomTypeModelIntegrationField,
+	CustomTypeModelIntegrationFieldsField,
+};
 export type { CustomTypeModelGroupField } from "./types/model/group";
 export type {
 	CustomTypeModelSliceZoneField,

--- a/src/types/api/repository.ts
+++ b/src/types/api/repository.ts
@@ -15,7 +15,7 @@ export interface Repository {
 	refs: Ref[];
 
 	/**
-	 * An identifier used to query content with the latest Integration Fields
+	 * An identifier used to query content with the latest integration fields
 	 * data.
 	 */
 	integrationFieldsRef: string | null;

--- a/src/types/api/repository.ts
+++ b/src/types/api/repository.ts
@@ -28,7 +28,7 @@ export interface Repository {
 	languages: Language[];
 
 	/**
-	 * A list of the repository's Custom Type API IDs mapped to their
+	 * A list of the repository's custom type API IDs mapped to their
 	 * human-readable name.
 	 */
 	types: Record<string, string>;

--- a/src/types/model/boolean.ts
+++ b/src/types/model/boolean.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A Boolean Custom Type field.
+ * A boolean custom type field.
  *
  * More details: {@link https://prismic.io/docs/boolean}
  */

--- a/src/types/model/color.ts
+++ b/src/types/model/color.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A Color Custom Type field.
+ * A color custom type field.
  *
  * More details: {@link https://prismic.io/docs/color}
  */

--- a/src/types/model/contentRelationship.ts
+++ b/src/types/model/contentRelationship.ts
@@ -3,7 +3,7 @@ import type { CustomTypeModelFieldType } from "./types";
 import type { CustomTypeModelLinkSelectType } from "./link";
 
 /**
- * A Content Relationship Custom Type field.
+ * A content relationship custom type field.
  *
  * More details:
  * {@link https://prismic.io/docs/content-relationship}

--- a/src/types/model/customType.ts
+++ b/src/types/model/customType.ts
@@ -16,7 +16,7 @@ export interface CustomTypeModel<
 	id: ID;
 
 	/**
-	 * The human readable name of the custom type Model.
+	 * The human readable name of the custom type model.
 	 */
 	// TODO: Revert to `label?: string | null` if `label` can be partial in: https://github.com/prismicio/prismic-types-internal/blob/HEAD/src/customtypes/CustomType.ts#L39
 	label: string | null | undefined;

--- a/src/types/model/customType.ts
+++ b/src/types/model/customType.ts
@@ -1,46 +1,46 @@
 import { CustomTypeModelField } from "./types";
 
 /**
- * A Prismic Custom Type model.
+ * A Prismic custom type model.
  *
- * @typeParam ID - API ID of the Custom Type.
- * @typeParam Definition - The Custom Type's tabs and their fields.
+ * @typeParam ID - API ID of the custom type.
+ * @typeParam Definition - The custom type's tabs and their fields.
  */
 export interface CustomTypeModel<
 	ID extends string = string,
 	Definition extends CustomTypeModelDefinition = CustomTypeModelDefinition,
 > {
 	/**
-	 * The ID of the Custom Type model.
+	 * The ID of the custom type model.
 	 */
 	id: ID;
 
 	/**
-	 * The human readable name of the Custom Type Model.
+	 * The human readable name of the custom type Model.
 	 */
 	// TODO: Revert to `label?: string | null` if `label` can be partial in: https://github.com/prismicio/prismic-types-internal/blob/HEAD/src/customtypes/CustomType.ts#L39
 	label: string | null | undefined;
 
 	/**
-	 * Determines if more than one document for the Custom Type can be created.
+	 * Determines if more than one document for the custom type can be created.
 	 */
 	repeatable: boolean;
 
 	/**
-	 * The Custom Type model definition.
+	 * The custom type model definition.
 	 */
 	json: Definition;
 
 	/**
-	 * Determines if new documents for the Custom Type can be created.
+	 * Determines if new documents for the custom type can be created.
 	 */
 	status: boolean;
 }
 
 /**
- * A Prismic Custom Type's tabs and their fields.
+ * A Prismic custom type's tabs and their fields.
  *
- * @typeParam TabName - Names of Custom Type tabs.
+ * @typeParam TabName - Names of custom type tabs.
  */
 export type CustomTypeModelDefinition<TabName extends string = string> = Record<
 	TabName,
@@ -48,7 +48,7 @@ export type CustomTypeModelDefinition<TabName extends string = string> = Record<
 >;
 
 /**
- * A Custom Type's tab. Each tab can contain any number of fields but is limited
+ * A custom type's tab. Each tab can contain any number of fields but is limited
  * to one Slice Zone.
  *
  * @typeParam FieldName - API IDs of the fields.

--- a/src/types/model/date.ts
+++ b/src/types/model/date.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A Date Custom Type field.
+ * A date custom type field.
  *
  * More details: {@link https://prismic.io/docs/date}
  */

--- a/src/types/model/embed.ts
+++ b/src/types/model/embed.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * An Embed Custom Type field.
+ * An embed custom type field.
  *
  * More details: {@link https://prismic.io/docs/embed}
  */

--- a/src/types/model/geoPoint.ts
+++ b/src/types/model/geoPoint.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A GeoPoint Custom Type field.
+ * A geopoint custom type field.
  *
  * More details: {@link https://prismic.io/docs/geopoint}
  */

--- a/src/types/model/group.ts
+++ b/src/types/model/group.ts
@@ -4,7 +4,7 @@ import type {
 } from "./types";
 
 /**
- * A Group Custom Type field.
+ * A group custom type field.
  *
  * More details: {@link https://prismic.io/docs/group}
  *

--- a/src/types/model/image.ts
+++ b/src/types/model/image.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * Dimension constraints for an Image Custom Type field.
+ * Dimension constraints for an image custom type field.
  *
  * More details: {@link https://prismic.io/docs/image}
  */
@@ -11,7 +11,7 @@ export interface CustomTypeModelImageConstraint {
 }
 
 /**
- * A thumbnail for an Image Custom Type field.
+ * A thumbnail for an image custom type field.
  *
  * More details: {@link https://prismic.io/docs/image}
  */
@@ -21,7 +21,7 @@ export interface CustomTypeModelImageThumbnail<Name extends string = string>
 }
 
 /**
- * An Image Custom Type field.
+ * An image custom type field.
  *
  * More details: {@link https://prismic.io/docs/image}
  */

--- a/src/types/model/integration.ts
+++ b/src/types/model/integration.ts
@@ -5,8 +5,8 @@ import type { CustomTypeModelFieldType } from "./types";
  *
  * More details: {@link https://prismic.io/docs/integration-fields}
  */
-export interface CustomTypeModelIntegrationFieldsField {
-	type: typeof CustomTypeModelFieldType.IntegrationFields;
+export interface CustomTypeModelIntegrationField {
+	type: typeof CustomTypeModelFieldType.Integration;
 	config?: {
 		label?: string | null;
 		placeholder?: string;

--- a/src/types/model/integrationFields.ts
+++ b/src/types/model/integrationFields.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * An Integration Fields Custom Type field.
+ * An integration custom type field.
  *
  * More details: {@link https://prismic.io/docs/integration-fields}
  */

--- a/src/types/model/keyText.ts
+++ b/src/types/model/keyText.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A Key Text Custom Type field.
+ * A key text custom type field.
  *
  * More details: {@link https://prismic.io/docs/key-text}
  */

--- a/src/types/model/link.ts
+++ b/src/types/model/link.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A Link Custom Type field.
+ * A link custom type field.
  *
  * More details:
  * {@link https://prismic.io/docs/link}
@@ -19,7 +19,7 @@ export interface CustomTypeModelLinkField {
 }
 
 /**
- * Type of a Link Custom Type field.
+ * Type of a Link custom type field.
  *
  * More details:
  * {@link https://prismic.io/docs/link}

--- a/src/types/model/link.ts
+++ b/src/types/model/link.ts
@@ -19,7 +19,7 @@ export interface CustomTypeModelLinkField {
 }
 
 /**
- * Type of a Link custom type field.
+ * Type of a link custom type field.
  *
  * More details:
  * {@link https://prismic.io/docs/link}

--- a/src/types/model/linkToMedia.ts
+++ b/src/types/model/linkToMedia.ts
@@ -3,7 +3,7 @@ import type { CustomTypeModelFieldType } from "./types";
 import type { CustomTypeModelLinkSelectType } from "./link";
 
 /**
- * A Link to Media Custom Type field.
+ * A link to media custom type field.
  *
  * More details:
  * {@link https://prismic.io/docs/media}

--- a/src/types/model/number.ts
+++ b/src/types/model/number.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A Number Custom Type field.
+ * A number custom type field.
  *
  * More details: {@link https://prismic.io/docs/number}
  */

--- a/src/types/model/richText.ts
+++ b/src/types/model/richText.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A Rich Text Custom Type field.
+ * A rich text custom type field.
  *
  * More details: {@link https://prismic.io/docs/rich-text-title}
  */
@@ -10,7 +10,7 @@ export type CustomTypeModelRichTextField =
 	| CustomTypeModelRichTextSingleField;
 
 /**
- * A Rich Text Custom Type field which supports multiple blocks of content.
+ * A rich text custom type field which supports multiple blocks of content.
  *
  * More details: {@link https://prismic.io/docs/rich-text-title}
  */
@@ -25,7 +25,7 @@ export interface CustomTypeModelRichTextMultiField {
 }
 
 /**
- * A Rich Text Custom Type field which supports one block of content.
+ * A rich text custom type field which supports one block of content.
  *
  * More details: {@link https://prismic.io/docs/rich-text-title}
  */

--- a/src/types/model/select.ts
+++ b/src/types/model/select.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A Select Custom Type field.
+ * A select custom type field.
  *
  * More details: {@link https://prismic.io/docs/select}
  *

--- a/src/types/model/sharedSlice.ts
+++ b/src/types/model/sharedSlice.ts
@@ -2,11 +2,11 @@ import type { SharedSliceModelVariation } from "./sharedSliceVariation";
 import type { CustomTypeModelSliceType } from "./sliceZone";
 
 /**
- * A Prismic Shared Slice model.
+ * A Prismic shared Slice model.
  *
  * More details: {@link https://prismic.io/docs/slice}
  *
- * @typeParam Variation - A variation for the Shared Slice.
+ * @typeParam Variation - A variation for the shared Slice.
  */
 export interface SharedSliceModel<
 	ID extends string = string,

--- a/src/types/model/sharedSliceVariation.ts
+++ b/src/types/model/sharedSliceVariation.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldForGroup } from "./types";
 
 /**
- * A Shared Slice variation.
+ * A shared Slice variation.
  *
  * More details: {@link https://prismic.io/docs/slice}
  *

--- a/src/types/model/slice.ts
+++ b/src/types/model/slice.ts
@@ -4,7 +4,7 @@ import type { CustomTypeModelGroupField } from "./group";
 import type { CustomTypeModelSliceType } from "./sliceZone";
 
 /**
- * A Slice for a Custom Type.
+ * A Slice for a custom type.
  *
  * More details: {@link https://prismic.io/docs/slice}
  *

--- a/src/types/model/sliceZone.ts
+++ b/src/types/model/sliceZone.ts
@@ -51,7 +51,7 @@ export const CustomTypeModelSliceType = {
 } as const;
 
 /**
- * A Shared Slice for a custom type.
+ * A shared Slice for a custom type.
  *
  * More details: {@link https://prismic.io/docs/slice}
  */

--- a/src/types/model/sliceZone.ts
+++ b/src/types/model/sliceZone.ts
@@ -3,7 +3,7 @@ import type { CustomTypeModelFieldType } from "./types";
 import type { CustomTypeModelLegacySlice, CustomTypeModelSlice } from "./slice";
 
 /**
- * A Slice Zone Custom Type field.
+ * A Slice Zone custom type field.
  *
  * More details: {@link https://prismic.io/docs/slice}
  */
@@ -51,7 +51,7 @@ export const CustomTypeModelSliceType = {
 } as const;
 
 /**
- * A Shared Slice for a Custom Type.
+ * A Shared Slice for a custom type.
  *
  * More details: {@link https://prismic.io/docs/slice}
  */

--- a/src/types/model/timestamp.ts
+++ b/src/types/model/timestamp.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A Timestamp Custom Type field.
+ * A timestamp custom type field.
  *
  * More details: {@link https://prismic.io/docs/timestamp}
  */

--- a/src/types/model/title.ts
+++ b/src/types/model/title.ts
@@ -1,7 +1,7 @@
 import { CustomTypeModelRichTextSingleField } from "./richText";
 
 /**
- * A Title Custom Type field.
+ * A title custom type field.
  *
  * More details: {@link https://prismic.io/docs/rich-text-title}
  */

--- a/src/types/model/types.ts
+++ b/src/types/model/types.ts
@@ -6,7 +6,7 @@ import type { CustomTypeModelEmbedField } from "./embed";
 import type { CustomTypeModelGeoPointField } from "./geoPoint";
 import type { CustomTypeModelGroupField } from "./group";
 import type { CustomTypeModelImageField } from "./image";
-import type { CustomTypeModelIntegrationField } from "./integrationFields";
+import type { CustomTypeModelIntegrationField } from "./integration";
 import type { CustomTypeModelKeyTextField } from "./keyText";
 import type { CustomTypeModelLinkField } from "./link";
 import type { CustomTypeModelLinkToMediaField } from "./linkToMedia";
@@ -40,6 +40,10 @@ export const CustomTypeModelFieldType = {
 	Text: "Text",
 	Timestamp: "Timestamp",
 	UID: "UID",
+	/**
+	 * @deprecated - Renamed to `Integration`.
+	 */
+	IntegrationFields: "IntegrationFields",
 	/**
 	 * @deprecated - Legacy field type. Use `Number` instead.
 	 */

--- a/src/types/model/types.ts
+++ b/src/types/model/types.ts
@@ -6,7 +6,7 @@ import type { CustomTypeModelEmbedField } from "./embed";
 import type { CustomTypeModelGeoPointField } from "./geoPoint";
 import type { CustomTypeModelGroupField } from "./group";
 import type { CustomTypeModelImageField } from "./image";
-import type { CustomTypeModelIntegrationFieldsField } from "./integrationFields";
+import type { CustomTypeModelIntegrationField } from "./integrationFields";
 import type { CustomTypeModelKeyTextField } from "./keyText";
 import type { CustomTypeModelLinkField } from "./link";
 import type { CustomTypeModelLinkToMediaField } from "./linkToMedia";
@@ -73,7 +73,7 @@ export type CustomTypeModelFieldForGroup =
 	| CustomTypeModelEmbedField
 	| CustomTypeModelGeoPointField
 	| CustomTypeModelImageField
-	| CustomTypeModelIntegrationFieldsField
+	| CustomTypeModelIntegrationField
 	| CustomTypeModelContentRelationshipField
 	| CustomTypeModelLinkField
 	| CustomTypeModelLinkToMediaField

--- a/src/types/model/types.ts
+++ b/src/types/model/types.ts
@@ -21,7 +21,7 @@ import type { CustomTypeModelTitleField } from "./title";
 import type { CustomTypeModelUIDField } from "./uid";
 
 /**
- * Type identifier for a Custom Type field.
+ * Type identifier for a custom type field.
  */
 export const CustomTypeModelFieldType = {
 	Boolean: "Boolean",
@@ -31,7 +31,7 @@ export const CustomTypeModelFieldType = {
 	GeoPoint: "GeoPoint",
 	Group: "Group",
 	Image: "Image",
-	IntegrationFields: "IntegrationFields",
+	Integration: "IntegrationFields",
 	Link: "Link",
 	Number: "Number",
 	Select: "Select",
@@ -55,7 +55,7 @@ export const CustomTypeModelFieldType = {
 } as const;
 
 /**
- * A Custom Type field.
+ * A custom type field.
  */
 export type CustomTypeModelField =
 	| CustomTypeModelUIDField
@@ -64,7 +64,7 @@ export type CustomTypeModelField =
 	| CustomTypeModelFieldForGroup;
 
 /**
- * Any Custom Type field that is valid for a Group field.
+ * Any custom type field that is valid for a group field.
  */
 export type CustomTypeModelFieldForGroup =
 	| CustomTypeModelBooleanField

--- a/src/types/model/uid.ts
+++ b/src/types/model/uid.ts
@@ -1,7 +1,7 @@
 import type { CustomTypeModelFieldType } from "./types";
 
 /**
- * A UID Custom Type field.
+ * A UID custom type field.
  *
  * More details: {@link https://prismic.io/docs/uid}
  */

--- a/src/types/value/boolean.ts
+++ b/src/types/value/boolean.ts
@@ -1,5 +1,5 @@
 /**
- * A Boolean field.
+ * A boolean field.
  *
  * @see More details: {@link https://prismic.io/docs/boolean}
  */

--- a/src/types/value/color.ts
+++ b/src/types/value/color.ts
@@ -1,7 +1,7 @@
 import type { FieldState } from "./types";
 
 /**
- * A Color field.
+ * A color field.
  *
  * @typeParam State - State of the field which determines its shape.
  * @see More details: {@link https://prismic.io/docs/color}

--- a/src/types/value/contentRelationship.ts
+++ b/src/types/value/contentRelationship.ts
@@ -25,7 +25,7 @@ export type ContentRelationshipField<
 	: FilledContentRelationshipField<TypeEnum, LangEnum, DataInterface>;
 
 /**
- * Links that refer to Documents
+ * Links that refer to documents
  */
 export interface FilledContentRelationshipField<
 	TypeEnum = string,

--- a/src/types/value/date.ts
+++ b/src/types/value/date.ts
@@ -1,7 +1,7 @@
 import type { FieldState } from "./types";
 
 /**
- * A Date field.
+ * A date field.
  *
  * @typeParam State - State of the field which determines its shape.
  * @see More details: {@link https://prismic.io/docs/date}

--- a/src/types/value/document.ts
+++ b/src/types/value/document.ts
@@ -14,7 +14,7 @@ export interface AlternateLanguage<TypeEnum = string, LangEnum = string> {
 }
 
 /**
- * Metadata for Prismic Document
+ * Metadata for Prismic document
  */
 export interface PrismicDocumentHeader<TypeEnum = string, LangEnum = string> {
 	/**
@@ -76,7 +76,7 @@ export interface PrismicDocumentHeader<TypeEnum = string, LangEnum = string> {
 /**
  * A Prismic document served through REST API v2.
  *
- * @see More details on Custom Types: {@link https://prismic.io/docs/custom-types}
+ * @see More details on custom types: {@link https://prismic.io/docs/custom-types}
  */
 export interface PrismicDocument<
 	DataInterface extends Record<
@@ -97,7 +97,7 @@ export interface PrismicDocument<
  * A Prismic document served through REST API v2. Does not contain a UID (a
  * unique identifier).
  *
- * @see More details on Custom Types: {@link https://prismic.io/docs/custom-types}
+ * @see More details on custom types: {@link https://prismic.io/docs/custom-types}
  * @see More details on the UID field: {@link https://prismic.io/docs/uid}
  */
 export interface PrismicDocumentWithoutUID<
@@ -123,7 +123,7 @@ export interface PrismicDocumentWithoutUID<
  * A Prismic document served through REST API v2. Contains a UID (a unique
  * identifier).
  *
- * @see More details on Custom Types: {@link https://prismic.io/docs/custom-types}
+ * @see More details on custom types: {@link https://prismic.io/docs/custom-types}
  * @see More details on the UID field: {@link https://prismic.io/docs/uid}
  */
 export interface PrismicDocumentWithUID<

--- a/src/types/value/embed.ts
+++ b/src/types/value/embed.ts
@@ -179,7 +179,7 @@ export type RichOEmbed = OEmbedBase<typeof OEmbedType.Rich> & {
 export type AnyOEmbed = PhotoOEmbed | VideoOEmbed | LinkOEmbed | RichOEmbed;
 
 /**
- * An Embed field.
+ * An embed field.
  *
  * @typeParam Data - Data provided by the URL's oEmbed provider.
  * @typeParam State - State of the field which determines its shape.

--- a/src/types/value/geoPoint.ts
+++ b/src/types/value/geoPoint.ts
@@ -1,7 +1,7 @@
 import type { EmptyObjectField, FieldState } from "./types";
 
 /**
- * A Geopoint field.
+ * A geopoint field.
  *
  * @typeParam State - State of the field which determines its shape.
  * @see More details: {@link https://prismic.io/docs/geopoint}

--- a/src/types/value/group.ts
+++ b/src/types/value/group.ts
@@ -1,7 +1,7 @@
 import type { AnyRegularField, FieldState } from "./types";
 
 /**
- * A Group field.
+ * A group field.
  *
  * More details: {@link https://prismic.io/docs/group}
  */

--- a/src/types/value/image.ts
+++ b/src/types/value/image.ts
@@ -1,11 +1,11 @@
 import type { FieldState, Simplify } from "./types";
 
 /**
- * An individual image within an Image field. The base image and each thumbnail
+ * An individual image within an image field. The base image and each thumbnail
  * uses this type.
  *
  * @typeParam State - State of the field which determines its shape.
- * @see {@link ImageField} for a full Image field type.
+ * @see {@link ImageField} for a full image field type.
  */
 export type ImageFieldImage<State extends FieldState = FieldState> =
 	State extends "empty" ? EmptyImageFieldImage : FilledImageFieldImage;
@@ -28,7 +28,7 @@ export interface EmptyImageFieldImage {
 }
 
 /**
- * Image Field
+ * An image field.
  *
  * **Note**: Passing `null` to the `ThumbnailNames` parameter is deprecated and
  * will be removed in a future version. Use `never` instead.
@@ -45,7 +45,7 @@ export type ImageField<
 	ThumbnailNames extends string | null = never,
 	State extends FieldState = FieldState,
 > =
-	// Simplify is necessary. Without it, Group and Slice types break for
+	// Simplify is necessary. Without it, group and Slice types break for
 	// unknown reasons. If you know why, please update this comment with an
 	// explanation. :)
 	Simplify<

--- a/src/types/value/integration.ts
+++ b/src/types/value/integration.ts
@@ -7,7 +7,7 @@ import type { FieldState } from "./types";
  * @typeParam State - State of the field which determines its shape.
  * @see More details: {@link https://prismic.io/docs/integration-fields}
  */
-export type IntegrationFields<
+export type IntegrationField<
 	Data extends Record<string, unknown> = Record<string, unknown>,
 	State extends FieldState = FieldState,
 > = State extends "empty" ? null : Data;

--- a/src/types/value/integrationFields.ts
+++ b/src/types/value/integrationFields.ts
@@ -1,7 +1,7 @@
 import type { FieldState } from "./types";
 
 /**
- * Integration Fields for Custom APIs
+ * An integration field.
  *
  * @typeParam Data - Data from the integrated API.
  * @typeParam State - State of the field which determines its shape.

--- a/src/types/value/keyText.ts
+++ b/src/types/value/keyText.ts
@@ -1,7 +1,7 @@
 import type { FieldState } from "./types";
 
 /**
- * A Key text field
+ * A key text field
  *
  * @typeParam State - State of the field which determines its shape.
  * @see More details: {@link https://prismic.io/docs/key-text}

--- a/src/types/value/link.ts
+++ b/src/types/value/link.ts
@@ -6,7 +6,7 @@ import type { LinkToMediaField } from "./linkToMedia";
 import type { SliceZone } from "./sliceZone";
 
 /**
- * Link Types
+ * Link types
  */
 export const LinkType = {
 	Any: "Any",
@@ -36,7 +36,7 @@ export interface FilledLinkToWebField {
 }
 
 /**
- * Link Field
+ * A link field.
  *
  * @typeParam TypeEnum - Type API ID of the document.
  * @typeParam LangEnum - Language API ID of the document.

--- a/src/types/value/linkToMedia.ts
+++ b/src/types/value/linkToMedia.ts
@@ -3,7 +3,7 @@ import type { FieldState } from "./types";
 import type { EmptyLinkField, LinkType } from "./link";
 
 /**
- * Link field that points to media
+ * A link field that points to media.
  *
  * @typeParam State - State of the field which determines its shape.
  */
@@ -13,7 +13,7 @@ export type LinkToMediaField<State extends FieldState = FieldState> =
 		: FilledLinkToMediaField;
 
 /**
- * Link that points to media
+ * A link that points to media.
  */
 export interface FilledLinkToMediaField {
 	link_type: typeof LinkType.Media;

--- a/src/types/value/number.ts
+++ b/src/types/value/number.ts
@@ -1,7 +1,7 @@
 import type { FieldState } from "./types";
 
 /**
- * A Number field
+ * A number field.
  *
  * @typeParam State - State of the field which determines its shape.
  * @see More details: {@link https://prismic.io/docs/number}

--- a/src/types/value/richText.ts
+++ b/src/types/value/richText.ts
@@ -43,70 +43,70 @@ export interface RTTextNodeBase {
 }
 
 /**
- * Rich Text `heading1` node
+ * Rich text `heading1` node
  */
 export interface RTHeading1Node extends RTTextNodeBase {
 	type: typeof RichTextNodeType.heading1;
 }
 
 /**
- * Rich Text `heading2` node
+ * Rich text `heading2` node
  */
 export interface RTHeading2Node extends RTTextNodeBase {
 	type: typeof RichTextNodeType.heading2;
 }
 
 /**
- * Rich Text `heading3` node
+ * Rich text `heading3` node
  */
 export interface RTHeading3Node extends RTTextNodeBase {
 	type: typeof RichTextNodeType.heading3;
 }
 
 /**
- * Rich Text `heading4` node
+ * Rich text `heading4` node
  */
 export interface RTHeading4Node extends RTTextNodeBase {
 	type: typeof RichTextNodeType.heading4;
 }
 
 /**
- * Rich Text `heading5` node
+ * Rich text `heading5` node
  */
 export interface RTHeading5Node extends RTTextNodeBase {
 	type: typeof RichTextNodeType.heading5;
 }
 
 /**
- * Rich Text `heading6` node
+ * Rich text `heading6` node
  */
 export interface RTHeading6Node extends RTTextNodeBase {
 	type: typeof RichTextNodeType.heading6;
 }
 
 /**
- * Rich Text `paragraph` node
+ * Rich text `paragraph` node
  */
 export interface RTParagraphNode extends RTTextNodeBase {
 	type: typeof RichTextNodeType.paragraph;
 }
 
 /**
- * Rich Text `preformatted` node
+ * Rich text `preformatted` node
  */
 export interface RTPreformattedNode extends RTTextNodeBase {
 	type: typeof RichTextNodeType.preformatted;
 }
 
 /**
- * Rich Text `list-item` node
+ * Rich text `list-item` node
  */
 export interface RTListItemNode extends RTTextNodeBase {
 	type: typeof RichTextNodeType.listItem;
 }
 
 /**
- * Rich Text `o-list-item` node for ordered lists
+ * Rich text `o-list-item` node for ordered lists
  */
 export interface RTOListItemNode extends RTTextNodeBase {
 	type: typeof RichTextNodeType.oListItem;
@@ -122,21 +122,21 @@ export interface RTSpanNodeBase {
 	end: number;
 }
 /**
- * Rich Text `strong` node
+ * Rich text `strong` node
  */
 export interface RTStrongNode extends RTSpanNodeBase {
 	type: typeof RichTextNodeType.strong;
 }
 
 /**
- * Rich Text `embed` node
+ * Rich text `embed` node
  */
 export interface RTEmNode extends RTSpanNodeBase {
 	type: typeof RichTextNodeType.em;
 }
 
 /**
- * Rich Text `label` node
+ * Rich text `label` node
  */
 export interface RTLabelNode extends RTSpanNodeBase {
 	type: typeof RichTextNodeType.label;
@@ -148,7 +148,7 @@ export interface RTLabelNode extends RTSpanNodeBase {
 // Media nodes
 
 /**
- * Rich Text `image` nodes. They could link to other documents, external web
+ * Rich text `image` nodes. They could link to other documents, external web
  * links and media fields
  */
 export type RTImageNode = {
@@ -167,7 +167,7 @@ export type RTImageNode = {
 };
 
 /**
- * Rich Text `embed` node
+ * Rich text `embed` node
  */
 export type RTEmbedNode = {
 	type: typeof RichTextNodeType.embed;
@@ -177,7 +177,7 @@ export type RTEmbedNode = {
 // Link nodes
 
 /**
- * Rich Text `a` node
+ * Rich text `a` node
  *
  * @see More details: {@link https://prismic.io/docs/rich-text-title#elements-and-styles}
  */
@@ -192,7 +192,7 @@ export interface RTLinkNode extends RTSpanNodeBase {
 // Serialization related nodes
 
 /**
- * Rich Text `list` node
+ * Rich text `list` node
  */
 export interface RTListNode {
 	type: typeof RichTextNodeType.list;
@@ -200,7 +200,7 @@ export interface RTListNode {
 }
 
 /**
- * Rich Text o-lost node
+ * Rich text o-lost node
  */
 export interface RTOListNode {
 	type: typeof RichTextNodeType.oList;
@@ -209,7 +209,7 @@ export interface RTOListNode {
 
 // This one is confusing but it's actually the inner content of a block
 /**
- * Rich Text `span` node
+ * Rich text `span` node
  */
 export interface RTSpanNode extends RTTextNodeBase {
 	type: typeof RichTextNodeType.span;
@@ -218,7 +218,7 @@ export interface RTSpanNode extends RTTextNodeBase {
 // Helpers
 
 /**
- * Nodes from a Rich Text Field
+ * Nodes from a rich text field
  */
 export type RTNode =
 	| RTHeading1Node
@@ -250,7 +250,7 @@ export type RTTextNode =
 	| RTOListItemNode;
 
 /**
- * Rich Text block nodes
+ * Rich text block nodes
  */
 export type RTBlockNode =
 	| RTHeading1Node
@@ -269,17 +269,17 @@ export type RTBlockNode =
 	| RTEmbedNode;
 
 /**
- * Inline Rich Text Nodes
+ * Inline rich text Nodes
  */
 export type RTInlineNode = RTStrongNode | RTEmNode | RTLabelNode | RTLinkNode;
 
 /**
- * All Rich Text nodes
+ * All rich text nodes
  */
 export type RTAnyNode = RTBlockNode | RTInlineNode | RTSpanNode;
 
 /**
- * Rich Text Field
+ * A rich text field.
  *
  * @see Rich Text field documentation: {@link https://prismic.io/docs/rich-text-title}
  */

--- a/src/types/value/richText.ts
+++ b/src/types/value/richText.ts
@@ -35,7 +35,7 @@ export const RichTextNodeType = {
 // Text nodes
 
 /**
- * Base to be extended by other RT Nodes.
+ * Base to be extended by other rich text nodes.
  */
 export interface RTTextNodeBase {
 	text: string;
@@ -269,7 +269,7 @@ export type RTBlockNode =
 	| RTEmbedNode;
 
 /**
- * Inline rich text Nodes
+ * Inline rich text nodes
  */
 export type RTInlineNode = RTStrongNode | RTEmNode | RTLabelNode | RTLinkNode;
 
@@ -281,7 +281,7 @@ export type RTAnyNode = RTBlockNode | RTInlineNode | RTSpanNode;
 /**
  * A rich text field.
  *
- * @see Rich Text field documentation: {@link https://prismic.io/docs/rich-text-title}
+ * @see Rich text field documentation: {@link https://prismic.io/docs/rich-text-title}
  */
 export type RichTextField<State extends FieldState = FieldState> =
 	State extends "empty" ? [] : [RTNode, ...RTNode[]];

--- a/src/types/value/select.ts
+++ b/src/types/value/select.ts
@@ -1,7 +1,7 @@
 import type { FieldState } from "./types";
 
 /**
- * A Select field
+ * A select field.
  *
  * @typeParam Enum - Selectable options for the field.
  * @typeParam State - State of the field which determines its shape.

--- a/src/types/value/sharedSlice.ts
+++ b/src/types/value/sharedSlice.ts
@@ -1,7 +1,7 @@
 import type { SharedSliceVariation } from "./sharedSliceVariation";
 
 /**
- * A Shared Slice.
+ * A shared Slice.
  *
  * @see More details: {@link https://prismic.io/docs/slice}
  */

--- a/src/types/value/sharedSlice.ts
+++ b/src/types/value/sharedSlice.ts
@@ -1,7 +1,7 @@
 import type { SharedSliceVariation } from "./sharedSliceVariation";
 
 /**
- * Shared Slice
+ * A Shared Slice.
  *
  * @see More details: {@link https://prismic.io/docs/slice}
  */

--- a/src/types/value/sharedSliceVariation.ts
+++ b/src/types/value/sharedSliceVariation.ts
@@ -1,5 +1,8 @@
 import type { AnyRegularField } from "./types";
 
+/**
+ * A Shared Slice variation.
+ */
 export interface SharedSliceVariation<
 	Variation = string,
 	PrimaryFields extends Record<string, AnyRegularField> = Record<

--- a/src/types/value/sharedSliceVariation.ts
+++ b/src/types/value/sharedSliceVariation.ts
@@ -1,7 +1,7 @@
 import type { AnyRegularField } from "./types";
 
 /**
- * A Shared Slice variation.
+ * A shared Slice variation.
  */
 export interface SharedSliceVariation<
 	Variation = string,

--- a/src/types/value/slice.ts
+++ b/src/types/value/slice.ts
@@ -1,7 +1,7 @@
 import type { AnyRegularField } from "./types";
 
 /**
- * Slice - Sections of your website
+ * A Slice - sections of your website.
  *
  * @see More details: {@link https://prismic.io/docs/slice}
  */

--- a/src/types/value/slice.ts
+++ b/src/types/value/slice.ts
@@ -1,7 +1,7 @@
 import type { AnyRegularField } from "./types";
 
 /**
- * A Slice - sections of your website.
+ * A Slice - sections of your webpages.
  *
  * @see More details: {@link https://prismic.io/docs/slice}
  */

--- a/src/types/value/timestamp.ts
+++ b/src/types/value/timestamp.ts
@@ -3,7 +3,7 @@ import type { FieldState } from "./types";
 import type { DateField } from "./date";
 
 /**
- * Simple Timestamp Field
+ * A timestamp field.
  *
  * @typeParam State - State of the field which determines its shape.
  */

--- a/src/types/value/title.ts
+++ b/src/types/value/title.ts
@@ -10,7 +10,7 @@ import type {
 } from "./richText";
 
 /**
- * Title Field
+ * A title field.
  *
  * @see Title field documentation: {@link https://prismic.io/docs/rich-text-title}
  */

--- a/src/types/value/types.ts
+++ b/src/types/value/types.ts
@@ -5,7 +5,7 @@ import type { DateField } from "./date";
 import type { EmbedField } from "./embed";
 import type { GeoPointField } from "./geoPoint";
 import type { ImageField } from "./image";
-import type { IntegrationFields } from "./integrationFields";
+import type { IntegrationField } from "./integration";
 import type { KeyTextField } from "./keyText";
 import type { LinkField } from "./link";
 import type { LinkToMediaField } from "./linkToMedia";
@@ -44,7 +44,7 @@ export type AnyRegularField =
 	| SelectField
 	| BooleanField
 	| GeoPointField
-	| IntegrationFields;
+	| IntegrationField;
 
 /**
  * Useful to flatten the type output to improve type hints shown in editors. And

--- a/src/types/webhook/apiUpdate.ts
+++ b/src/types/webhook/apiUpdate.ts
@@ -25,7 +25,7 @@ interface WebhookBodyAPIUpdateOperations<T> {
 }
 
 /**
- * Metadata representing a mask (also called a Custom Type).
+ * Metadata representing a mask (also called a custom type).
  *
  * @see More details: {@link https://prismic.io/docs/custom-types}
  */

--- a/test/client-graphQLFetch.test.ts
+++ b/test/client-graphQLFetch.test.ts
@@ -68,6 +68,7 @@ it("merges provided headers with defaults", async (ctx) => {
 	expect(json).toStrictEqual(graphqlResponse);
 });
 
+// TODO: This test doesn't seem to test what the description claims.
 it("includes Authorization header if access token is provided", async (ctx) => {
 	const repositoryResponse = ctx.mock.api.repository();
 	repositoryResponse.integrationFieldsRef = ctx.mock.api.ref().ref;
@@ -98,7 +99,8 @@ it("includes Authorization header if access token is provided", async (ctx) => {
 	expect(json).toStrictEqual(graphqlResponse);
 });
 
-it("includes Integration Fields header if ref is available", async (ctx) => {
+// TODO: This test doesn't seem to test what the description claims.
+it("includes integration fields header if ref is available", async (ctx) => {
 	const repositoryResponse = ctx.mock.api.repository();
 	const accessToken = "accessToken";
 

--- a/test/helpers-isFilled.test.ts
+++ b/test/helpers-isFilled.test.ts
@@ -76,11 +76,14 @@ it("image thumbnail", () => {
 });
 
 it("integration fields", (ctx) => {
-	expect(isFilled.integrationFields(null)).toBe(false);
-	expect(isFilled.integrationFields(undefined)).toBe(false);
-	expect(isFilled.integrationFields(ctx.mock.value.integrationFields())).toBe(
+	expect(isFilled.integrationField(null)).toBe(false);
+	expect(isFilled.integrationField(undefined)).toBe(false);
+	expect(isFilled.integrationField(ctx.mock.value.integrationFields())).toBe(
 		true,
 	);
+});
+it("aliases integrationFields to integrationField", () => {
+	expect(isFilled.integrationFields).toBe(isFilled.integrationField);
 });
 
 it("key text", (ctx) => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -53,7 +53,7 @@ it("custom type field type mapping", () => {
 		GeoPoint: "GeoPoint",
 		Group: "Group",
 		Image: "Image",
-		IntegrationFields: "IntegrationFields",
+		IntegrationField: "IntegrationField",
 		Link: "Link",
 		Number: "Number",
 		Select: "Select",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -45,7 +45,7 @@ it("embed type mapping", () => {
 });
 
 it("custom type field type mapping", () => {
-	expect(prismic.CustomTypeModelFieldType).toMatchObject({
+	expect(prismic.CustomTypeModelFieldType).toStrictEqual({
 		Boolean: "Boolean",
 		Color: "Color",
 		Date: "Date",
@@ -53,7 +53,7 @@ it("custom type field type mapping", () => {
 		GeoPoint: "GeoPoint",
 		Group: "Group",
 		Image: "Image",
-		IntegrationField: "IntegrationField",
+		Integration: "IntegrationFields",
 		Link: "Link",
 		Number: "Number",
 		Select: "Select",
@@ -62,6 +62,11 @@ it("custom type field type mapping", () => {
 		Text: "Text",
 		Timestamp: "Timestamp",
 		UID: "UID",
+		// Deprecated fields
+		IntegrationFields: "IntegrationFields",
+		Range: "Range",
+		Separator: "Separator",
+		LegacySlices: "Choice",
 	});
 });
 

--- a/test/types/customType-integration.types.ts
+++ b/test/types/customType-integration.types.ts
@@ -3,7 +3,7 @@ import { expectNever, expectType } from "ts-expect";
 
 import * as prismic from "../../src";
 
-(value: prismic.CustomTypeModelIntegrationFieldsField): true => {
+(value: prismic.CustomTypeModelIntegrationField): true => {
 	switch (typeof value) {
 		case "object": {
 			if (value === null) {
@@ -19,8 +19,8 @@ import * as prismic from "../../src";
 	}
 };
 
-expectType<prismic.CustomTypeModelIntegrationFieldsField>({
-	type: prismic.CustomTypeModelFieldType.IntegrationFields,
+expectType<prismic.CustomTypeModelIntegrationField>({
+	type: prismic.CustomTypeModelFieldType.Integration,
 	config: {
 		label: "string",
 		catalog: "string",
@@ -30,8 +30,8 @@ expectType<prismic.CustomTypeModelIntegrationFieldsField>({
 /**
  * Supports optional placeholder.
  */
-expectType<prismic.CustomTypeModelIntegrationFieldsField>({
-	type: prismic.CustomTypeModelFieldType.IntegrationFields,
+expectType<prismic.CustomTypeModelIntegrationField>({
+	type: prismic.CustomTypeModelFieldType.Integration,
 	config: {
 		label: "string",
 		placeholder: "string",
@@ -42,7 +42,7 @@ expectType<prismic.CustomTypeModelIntegrationFieldsField>({
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.CustomTypeModelIntegrationFieldsField>(
+expectType<prismic.CustomTypeModelIntegrationField>(
 	{} as prismicTI.CustomTypes.Widgets.Nestable.IntegrationField,
 );
 
@@ -50,5 +50,5 @@ expectType<prismic.CustomTypeModelIntegrationFieldsField>(
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
 expectType<prismicTI.CustomTypes.Widgets.Nestable.IntegrationField>(
-	{} as prismic.CustomTypeModelIntegrationFieldsField,
+	{} as prismic.CustomTypeModelIntegrationField,
 );

--- a/test/types/customType-linkToMedia.types.ts
+++ b/test/types/customType-linkToMedia.types.ts
@@ -45,8 +45,8 @@ expectType<prismic.CustomTypeModelLinkToMediaField>({
 expectType<prismic.CustomTypeModelLinkToMediaField>(
 	{} as prismicTI.CustomTypes.Widgets.Nestable.Link & {
 		// We must manually narrow `@prismicio/types-internal`'s type
-		// to match a Link to Media field; `@prismicio/types-internal`
-		// does not contain a Link to Media-specific type.
+		// to match a link to media field; `@prismicio/types-internal`
+		// does not contain a link to media-specific type.
 		config?: { select: "media" };
 	},
 );

--- a/test/types/customType.types.ts
+++ b/test/types/customType.types.ts
@@ -236,7 +236,7 @@ expectType<
 expectType<
 	TypeOf<
 		prismic.CustomTypeModelFieldForGroup,
-		prismic.CustomTypeModelIntegrationFieldsField
+		prismic.CustomTypeModelIntegrationField
 	>
 >(true);
 expectType<

--- a/test/types/fields-integration.types.ts
+++ b/test/types/fields-integration.types.ts
@@ -2,7 +2,7 @@ import { expectNever, expectType } from "ts-expect";
 
 import * as prismic from "../../src";
 
-(value: prismic.IntegrationFields): true => {
+(value: prismic.IntegrationField): true => {
 	switch (typeof value) {
 		case "object": {
 			if (value === null) {
@@ -21,13 +21,13 @@ import * as prismic from "../../src";
 /**
  * Filled state.
  */
-expectType<prismic.IntegrationFields>({
+expectType<prismic.IntegrationField>({
 	foo: "bar",
 });
-expectType<prismic.IntegrationFields<Record<string, unknown>, "filled">>({
+expectType<prismic.IntegrationField<Record<string, unknown>, "filled">>({
 	foo: "bar",
 });
-expectType<prismic.IntegrationFields<Record<string, unknown>, "empty">>(
+expectType<prismic.IntegrationField<Record<string, unknown>, "empty">>(
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	{
 		foo: "bar",
@@ -37,9 +37,9 @@ expectType<prismic.IntegrationFields<Record<string, unknown>, "empty">>(
 /**
  * Empty state.
  */
-expectType<prismic.IntegrationFields>(null);
-expectType<prismic.IntegrationFields<Record<string, unknown>, "empty">>(null);
-expectType<prismic.IntegrationFields<Record<string, unknown>, "filled">>(
+expectType<prismic.IntegrationField>(null);
+expectType<prismic.IntegrationField<Record<string, unknown>, "empty">>(null);
+expectType<prismic.IntegrationField<Record<string, unknown>, "filled">>(
 	// @ts-expect-error - Filled fields cannot contain an empty value.
 	null,
 );
@@ -47,10 +47,10 @@ expectType<prismic.IntegrationFields<Record<string, unknown>, "filled">>(
 /**
  * Supports custom blob type.
  */
-expectType<prismic.IntegrationFields<{ foo: "bar" }>>({
+expectType<prismic.IntegrationField<{ foo: "bar" }>>({
 	foo: "bar",
 });
-expectType<prismic.IntegrationFields<{ foo: "bar" }>>({
+expectType<prismic.IntegrationField<{ foo: "bar" }>>({
 	// @ts-expect-error - Blob should match the given type.
 	baz: "qux",
 });

--- a/test/types/fields-sharedSlice.types.ts
+++ b/test/types/fields-sharedSlice.types.ts
@@ -28,7 +28,7 @@ expectType<prismic.SharedSlice>({
 });
 
 /**
- * Supports custom Shared Slice type API ID.
+ * Supports custom shared Slice type API ID.
  */
 expectType<prismic.SharedSlice<"foo">>({
 	slice_type: "foo",

--- a/test/types/fields-sliceZone.types.ts
+++ b/test/types/fields-sliceZone.types.ts
@@ -78,7 +78,7 @@ expectType<prismic.SliceZone<prismic.Slice<"foo">>>([
 ]);
 
 /**
- * Supports custom Shared Slice definitions.
+ * Supports custom shared Slice definitions.
  */
 expectType<prismic.SliceZone<prismic.SharedSlice<"foo">>>([
 	{

--- a/test/types/fields.types.ts
+++ b/test/types/fields.types.ts
@@ -27,7 +27,7 @@ expectType<TypeOf<prismic.AnyRegularField, prismic.DateField>>(true);
 expectType<TypeOf<prismic.AnyRegularField, prismic.EmbedField>>(true);
 expectType<TypeOf<prismic.AnyRegularField, prismic.GeoPointField>>(true);
 expectType<TypeOf<prismic.AnyRegularField, prismic.ImageField>>(true);
-expectType<TypeOf<prismic.AnyRegularField, prismic.IntegrationFields>>(true);
+expectType<TypeOf<prismic.AnyRegularField, prismic.IntegrationField>>(true);
 expectType<TypeOf<prismic.AnyRegularField, prismic.KeyTextField>>(true);
 expectType<TypeOf<prismic.AnyRegularField, prismic.LinkField>>(true);
 expectType<TypeOf<prismic.AnyRegularField, prismic.LinkToMediaField>>(true);

--- a/test/types/helpers-isFilled.types.ts
+++ b/test/types/helpers-isFilled.types.ts
@@ -447,66 +447,66 @@ type EmbedData = prismic.VideoOEmbed & { foo: string };
  * Integration fields
  */
 
-type IntegrationFieldsDefault = Record<string, unknown>;
+type IntegrationFieldDefault = Record<string, unknown>;
 
 // Default
-(value: prismic.IntegrationFields) => {
-	if (prismic.isFilled.integrationFields(value)) {
+(value: prismic.IntegrationField) => {
+	if (prismic.isFilled.integrationField(value)) {
 		expectType<
 			TypeEqual<
-				prismic.IntegrationFields<IntegrationFieldsDefault, "filled">,
+				prismic.IntegrationField<IntegrationFieldDefault, "filled">,
 				typeof value
 			>
 		>(true);
 		expectType<
 			TypeEqual<
-				prismic.IntegrationFields<IntegrationFieldsDefault, "empty">,
+				prismic.IntegrationField<IntegrationFieldDefault, "empty">,
 				typeof value
 			>
 		>(false);
 	} else {
 		expectType<
 			TypeEqual<
-				prismic.IntegrationFields<IntegrationFieldsDefault, "filled">,
+				prismic.IntegrationField<IntegrationFieldDefault, "filled">,
 				typeof value
 			>
 		>(false);
 		expectType<
 			TypeEqual<
-				prismic.IntegrationFields<IntegrationFieldsDefault, "empty">,
+				prismic.IntegrationField<IntegrationFieldDefault, "empty">,
 				typeof value
 			>
 		>(true);
 	}
 };
 
-type IntegrationFieldsData = { foo: string };
+type IntegrationFieldData = { foo: string };
 
 // With data
-(value: prismic.IntegrationFields<IntegrationFieldsData>) => {
-	if (prismic.isFilled.integrationFields(value)) {
+(value: prismic.IntegrationField<IntegrationFieldData>) => {
+	if (prismic.isFilled.integrationField(value)) {
 		expectType<
 			TypeEqual<
-				prismic.IntegrationFields<IntegrationFieldsData, "filled">,
+				prismic.IntegrationField<IntegrationFieldData, "filled">,
 				typeof value
 			>
 		>(true);
 		expectType<
 			TypeEqual<
-				prismic.IntegrationFields<IntegrationFieldsData, "empty">,
+				prismic.IntegrationField<IntegrationFieldData, "empty">,
 				typeof value
 			>
 		>(false);
 	} else {
 		expectType<
 			TypeEqual<
-				prismic.IntegrationFields<IntegrationFieldsData, "filled">,
+				prismic.IntegrationField<IntegrationFieldData, "filled">,
 				typeof value
 			>
 		>(false);
 		expectType<
 			TypeEqual<
-				prismic.IntegrationFields<IntegrationFieldsData, "empty">,
+				prismic.IntegrationField<IntegrationFieldData, "empty">,
 				typeof value
 			>
 		>(true);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates documentation and APIs to use the latest field name styles.

The following changes are included:

- "Integration Fields" → "integration" (e.g. "An integration field")
- "Custom Type" → "custom type" (e.g. "A custom type model")
- "Shared Slice" → "shared Slice" (e.g. "A shared Slice model")
- Lowercase all field names (e.g. "Rich Text" → "rich text")

### Integration fields

This package exports APIs that use the terms `IntegrationFields` and `integrationFields`. This PR deprecates, not removes, those APIs in favor of the renamed versions.

Please see the changed files for a full list of deprecated APIs.

cc @samlfair

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦮
