### PR TITLE
chore(@prismicio/types-internal): upgrade @prismicio/types-internal dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 			},
 			"devDependencies": {
 				"@prismicio/mock": "^0.2.0",
-				"@prismicio/types-internal": "^1.5.3",
+				"@prismicio/types-internal": "2.0.0-alpha.11",
 				"@size-limit/preset-small-lib": "^8.2.4",
 				"@trivago/prettier-plugin-sort-imports": "^4.1.1",
 				"@typescript-eslint/eslint-plugin": "^5.59.0",
@@ -911,9 +911,9 @@
 			}
 		},
 		"node_modules/@prismicio/types-internal": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-1.5.3.tgz",
-			"integrity": "sha512-GHV2rZsCUJJQDF7gF2to0F/3eolTXD/ng7ClfbqtHO3udJ5D+iifocAEnsEdi+Y9VKT/WVgyBi/dA6GAhNMHmQ==",
+			"version": "2.0.0-alpha.11",
+			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-2.0.0-alpha.11.tgz",
+			"integrity": "sha512-gV51WJatjBrkFUEeCFKXqCNzVjryuDqPVVdFz98SDqlFzK5jJZv4SoYKLpi1/IBeOOCwa+bfdvwGshZyCNxr2Q==",
 			"dev": true,
 			"dependencies": {
 				"monocle-ts": "^2.3.11",
@@ -8334,9 +8334,9 @@
 			"integrity": "sha512-xHPBWg+lPcl8U97VB/2oYK3MJlQoVPZq91hbeQO8WRyvq+zgpNST3xFOTk8SkQpgoH6wd50AxGZELvPrpojajQ=="
 		},
 		"@prismicio/types-internal": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-1.5.3.tgz",
-			"integrity": "sha512-GHV2rZsCUJJQDF7gF2to0F/3eolTXD/ng7ClfbqtHO3udJ5D+iifocAEnsEdi+Y9VKT/WVgyBi/dA6GAhNMHmQ==",
+			"version": "2.0.0-alpha.11",
+			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-2.0.0-alpha.11.tgz",
+			"integrity": "sha512-gV51WJatjBrkFUEeCFKXqCNzVjryuDqPVVdFz98SDqlFzK5jJZv4SoYKLpi1/IBeOOCwa+bfdvwGshZyCNxr2Q==",
 			"dev": true,
 			"requires": {
 				"monocle-ts": "^2.3.11",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.2.0",
-		"@prismicio/types-internal": "^1.5.3",
+		"@prismicio/types-internal": "2.0.0-alpha.11",
 		"@size-limit/preset-small-lib": "^8.2.4",
 		"@trivago/prettier-plugin-sort-imports": "^4.1.1",
 		"@typescript-eslint/eslint-plugin": "^5.59.0",

--- a/test/types/customType-boolean.types.ts
+++ b/test/types/customType-boolean.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -42,12 +43,12 @@ expectType<prismic.CustomTypeModelBooleanField>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelBooleanField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.BooleanField,
+	{} as prismicTICustomTypes.BooleanField,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.BooleanField>(
+expectType<prismicTICustomTypes.BooleanField>(
 	{} as prismic.CustomTypeModelBooleanField,
 );

--- a/test/types/customType-color.types.ts
+++ b/test/types/customType-color.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -40,13 +41,9 @@ expectType<prismic.CustomTypeModelColorField>({
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.CustomTypeModelColorField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Color,
-);
+expectType<prismic.CustomTypeModelColorField>({} as prismicTICustomTypes.Color);
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Color>(
-	{} as prismic.CustomTypeModelColorField,
-);
+expectType<prismicTICustomTypes.Color>({} as prismic.CustomTypeModelColorField);

--- a/test/types/customType-contentRelationship.types.ts
+++ b/test/types/customType-contentRelationship.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -99,7 +100,7 @@ expectType<prismic.CustomTypeModelContentRelationshipField<string, "foo">>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelContentRelationshipField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Link & {
+	{} as prismicTICustomTypes.Link & {
 		// We must manually narrow `@prismicio/types-internal`'s type
 		// to match a Content Relationship field;
 		// `@prismicio/types-internal` does not contain a Content
@@ -111,6 +112,6 @@ expectType<prismic.CustomTypeModelContentRelationshipField>(
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Link>(
+expectType<prismicTICustomTypes.Link>(
 	{} as prismic.CustomTypeModelContentRelationshipField,
 );

--- a/test/types/customType-date.types.ts
+++ b/test/types/customType-date.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -40,13 +41,9 @@ expectType<prismic.CustomTypeModelDateField>({
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.CustomTypeModelDateField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Date,
-);
+expectType<prismic.CustomTypeModelDateField>({} as prismicTICustomTypes.Date);
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Date>(
-	{} as prismic.CustomTypeModelDateField,
-);
+expectType<prismicTICustomTypes.Date>({} as prismic.CustomTypeModelDateField);

--- a/test/types/customType-embed.types.ts
+++ b/test/types/customType-embed.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -40,13 +41,9 @@ expectType<prismic.CustomTypeModelEmbedField>({
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.CustomTypeModelEmbedField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Embed,
-);
+expectType<prismic.CustomTypeModelEmbedField>({} as prismicTICustomTypes.Embed);
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Embed>(
-	{} as prismic.CustomTypeModelEmbedField,
-);
+expectType<prismicTICustomTypes.Embed>({} as prismic.CustomTypeModelEmbedField);

--- a/test/types/customType-geoPoint.types.ts
+++ b/test/types/customType-geoPoint.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -42,12 +43,12 @@ expectType<prismic.CustomTypeModelGeoPointField>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelGeoPointField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.GeoPoint,
+	{} as prismicTICustomTypes.GeoPoint,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.GeoPoint>(
+expectType<prismicTICustomTypes.GeoPoint>(
 	{} as prismic.CustomTypeModelGeoPointField,
 );

--- a/test/types/customType-group.types.ts
+++ b/test/types/customType-group.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -79,13 +80,9 @@ expectType<
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.CustomTypeModelGroupField>(
-	{} as prismicTI.CustomTypes.Widgets.Group,
-);
+expectType<prismic.CustomTypeModelGroupField>({} as prismicTICustomTypes.Group);
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Group>(
-	{} as prismic.CustomTypeModelGroupField,
-);
+expectType<prismicTICustomTypes.Group>({} as prismic.CustomTypeModelGroupField);

--- a/test/types/customType-image.types.ts
+++ b/test/types/customType-image.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -130,13 +131,9 @@ expectType<prismic.CustomTypeModelImageThumbnail<"Foo">>({
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.CustomTypeModelImageField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Image,
-);
+expectType<prismic.CustomTypeModelImageField>({} as prismicTICustomTypes.Image);
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Image>(
-	{} as prismic.CustomTypeModelImageField,
-);
+expectType<prismicTICustomTypes.Image>({} as prismic.CustomTypeModelImageField);

--- a/test/types/customType-integration.types.ts
+++ b/test/types/customType-integration.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -43,12 +44,12 @@ expectType<prismic.CustomTypeModelIntegrationField>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelIntegrationField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.IntegrationField,
+	{} as prismicTICustomTypes.IntegrationField,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.IntegrationField>(
+expectType<prismicTICustomTypes.IntegrationField>(
 	{} as prismic.CustomTypeModelIntegrationField,
 );

--- a/test/types/customType-keyText.types.ts
+++ b/test/types/customType-keyText.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -41,12 +42,12 @@ expectType<prismic.CustomTypeModelKeyTextField>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelKeyTextField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Text,
+	{} as prismicTICustomTypes.Text,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Text>(
+expectType<prismicTICustomTypes.Text>(
 	{} as prismic.CustomTypeModelKeyTextField,
 );

--- a/test/types/customType-link.types.ts
+++ b/test/types/customType-link.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -62,13 +63,9 @@ expectType<prismic.CustomTypeModelLinkField>({
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.CustomTypeModelLinkField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Link,
-);
+expectType<prismic.CustomTypeModelLinkField>({} as prismicTICustomTypes.Link);
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Link>(
-	{} as prismic.CustomTypeModelLinkField,
-);
+expectType<prismicTICustomTypes.Link>({} as prismic.CustomTypeModelLinkField);

--- a/test/types/customType-linkToMedia.types.ts
+++ b/test/types/customType-linkToMedia.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -43,7 +44,7 @@ expectType<prismic.CustomTypeModelLinkToMediaField>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelLinkToMediaField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Link & {
+	{} as prismicTICustomTypes.Link & {
 		// We must manually narrow `@prismicio/types-internal`'s type
 		// to match a link to media field; `@prismicio/types-internal`
 		// does not contain a link to media-specific type.
@@ -54,6 +55,6 @@ expectType<prismic.CustomTypeModelLinkToMediaField>(
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Link>(
+expectType<prismicTICustomTypes.Link>(
 	{} as prismic.CustomTypeModelLinkToMediaField,
 );

--- a/test/types/customType-number.types.ts
+++ b/test/types/customType-number.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -41,12 +42,12 @@ expectType<prismic.CustomTypeModelNumberField>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelNumberField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Number,
+	{} as prismicTICustomTypes.Number,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Number>(
+expectType<prismicTICustomTypes.Number>(
 	{} as prismic.CustomTypeModelNumberField,
 );

--- a/test/types/customType-richText.types.ts
+++ b/test/types/customType-richText.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { TypeOf, expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -81,12 +82,12 @@ expectType<prismic.CustomTypeModelRichTextField>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelRichTextField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.RichText,
+	{} as prismicTICustomTypes.RichText,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.RichText>(
+expectType<prismicTICustomTypes.RichText>(
 	{} as prismic.CustomTypeModelRichTextField,
 );

--- a/test/types/customType-select.types.ts
+++ b/test/types/customType-select.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -108,12 +109,12 @@ expectType<prismic.CustomTypeModelSelectField<"foo">>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelSelectField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Select,
+	{} as prismicTICustomTypes.Select,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Select>(
+expectType<prismicTICustomTypes.Select>(
 	{} as prismic.CustomTypeModelSelectField,
 );

--- a/test/types/customType-sharedSlice.types.ts
+++ b/test/types/customType-sharedSlice.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -27,12 +28,12 @@ expectType<prismic.CustomTypeModelSharedSlice>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelSharedSlice>(
-	{} as prismicTI.CustomTypes.Widgets.Slices.SharedSliceRef,
+	{} as prismicTICustomTypes.SharedSliceRef,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Slices.SharedSliceRef>(
+expectType<prismicTICustomTypes.SharedSliceRef>(
 	{} as prismic.CustomTypeModelSharedSlice,
 );

--- a/test/types/customType-sharedSliceModel.types.ts
+++ b/test/types/customType-sharedSliceModel.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -109,13 +110,9 @@ expectType<
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.SharedSliceModel>(
-	{} as prismicTI.CustomTypes.Widgets.Slices.SharedSlice,
-);
+expectType<prismic.SharedSliceModel>({} as prismicTICustomTypes.SharedSlice);
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Slices.SharedSlice>(
-	{} as prismic.SharedSliceModel,
-);
+expectType<prismicTICustomTypes.SharedSlice>({} as prismic.SharedSliceModel);

--- a/test/types/customType-sharedSliceModelVariation.types.ts
+++ b/test/types/customType-sharedSliceModelVariation.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -140,12 +141,12 @@ expectType<
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.SharedSliceModelVariation>(
-	{} as prismicTI.CustomTypes.Widgets.Slices.Variation,
+	{} as prismicTICustomTypes.Variation,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Slices.Variation>(
+expectType<prismicTICustomTypes.Variation>(
 	{} as prismic.SharedSliceModelVariation,
 );

--- a/test/types/customType-slice.types.ts
+++ b/test/types/customType-slice.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -108,12 +109,12 @@ expectType<
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelSlice>(
-	{} as prismicTI.CustomTypes.Widgets.Slices.CompositeSlice,
+	{} as prismicTICustomTypes.CompositeSlice,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Slices.CompositeSlice>(
+expectType<prismicTICustomTypes.CompositeSlice>(
 	{} as prismic.CustomTypeModelSlice,
 );

--- a/test/types/customType-sliceZone.types.ts
+++ b/test/types/customType-sliceZone.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -93,12 +94,12 @@ expectType<
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelSliceZoneField>(
-	{} as prismicTI.CustomTypes.Widgets.Slices.SliceZone.DynamicSlices,
+	{} as prismicTICustomTypes.DynamicSlices,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Slices.SliceZone.DynamicSlices>(
+expectType<prismicTICustomTypes.DynamicSlices>(
 	{} as prismic.CustomTypeModelSliceZoneField,
 );

--- a/test/types/customType-timestamp.types.ts
+++ b/test/types/customType-timestamp.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -41,12 +42,12 @@ expectType<prismic.CustomTypeModelTimestampField>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelTimestampField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.Timestamp,
+	{} as prismicTICustomTypes.Timestamp,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.Timestamp>(
+expectType<prismicTICustomTypes.Timestamp>(
 	{} as prismic.CustomTypeModelTimestampField,
 );

--- a/test/types/customType-title.types.ts
+++ b/test/types/customType-title.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -43,12 +44,12 @@ expectType<prismic.CustomTypeModelTitleField>({
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelTitleField>(
-	{} as prismicTI.CustomTypes.Widgets.Nestable.RichText,
+	{} as prismicTICustomTypes.RichText,
 );
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.Nestable.RichText>(
+expectType<prismicTICustomTypes.RichText>(
 	{} as prismic.CustomTypeModelTitleField,
 );

--- a/test/types/customType-uid.types.ts
+++ b/test/types/customType-uid.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -40,13 +41,9 @@ expectType<prismic.CustomTypeModelUIDField>({
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.CustomTypeModelUIDField>(
-	{} as prismicTI.CustomTypes.Widgets.UID,
-);
+expectType<prismic.CustomTypeModelUIDField>({} as prismicTICustomTypes.UID);
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.Widgets.UID>(
-	{} as prismic.CustomTypeModelUIDField,
-);
+expectType<prismicTICustomTypes.UID>({} as prismic.CustomTypeModelUIDField);

--- a/test/types/customType.types.ts
+++ b/test/types/customType.types.ts
@@ -1,5 +1,6 @@
-import * as prismicTI from "@prismicio/types-internal";
 import { TypeOf, expectNever, expectType } from "ts-expect";
+
+import * as prismicTICustomTypes from "@prismicio/types-internal/lib/customtypes";
 
 import * as prismic from "../../src";
 
@@ -323,9 +324,9 @@ expectType<
 /**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
-expectType<prismic.CustomTypeModel>({} as prismicTI.CustomTypes.CustomType);
+expectType<prismic.CustomTypeModel>({} as prismicTICustomTypes.CustomType);
 
 /**
  * `@prismicio/types-internal` extends `@prismicio/types`
  */
-expectType<prismicTI.CustomTypes.CustomType>({} as prismic.CustomTypeModel);
+expectType<prismicTICustomTypes.CustomType>({} as prismic.CustomTypeModel);


### PR DESCRIPTION
## Types of changes

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

For the new feature "Page Types" we need to handle a new property "format".
[DT-1302 - AADev, I need to add the format property to the public prismic-client](https://linear.app/prismic/issue/DT-1302/aadev-i-need-to-add-the-format-property-to-the-public-prismic-client)

A stable release v2 will soon be done, so this PR is to prepare the upgrade with the new format property.

DRAFT because of the alpha but if you're ok to merge the alpha, I'm also ok 😄🤷‍♂️

## Checklist:

- ~~My change requires an update to the official documentation.~~
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.
