### PR TITLE
fix: reduce the return type of `unstable_mapSliceZone()` to only include necessary properties

### DIFF
--- a/src/helpers/unstable_mapSliceZone.ts
+++ b/src/helpers/unstable_mapSliceZone.ts
@@ -18,9 +18,20 @@ type MaybeLazyModule<T> = T | LazyModule<T>;
  */
 type ExtractSliceType<TSlice extends SliceLike> = TSlice extends Slice
 	? TSlice["slice_type"]
-	: TSlice extends SliceGraphQLLike
+	: TSlice extends SliceLikeGraphQL
 	? TSlice["type"]
 	: never;
+
+/**
+ * The minimum required properties to represent a Prismic Slice from the Prismic
+ * Rest API V2 for the `unstable_mapSliceZone()` helper.
+ *
+ * @typeParam SliceType - Type name of the Slice.
+ */
+type SliceLikeRestV2<TSliceType extends string = string> = Pick<
+	Slice<TSliceType>,
+	"id" | "slice_type"
+>;
 
 /**
  * The minimum required properties to represent a Prismic Slice from the Prismic
@@ -28,7 +39,7 @@ type ExtractSliceType<TSlice extends SliceLike> = TSlice extends Slice
  *
  * @typeParam SliceType - Type name of the Slice.
  */
-type SliceGraphQLLike<TSliceType extends string = string> = {
+type SliceLikeGraphQL<TSliceType extends string = string> = {
 	type: Slice<TSliceType>["slice_type"];
 };
 
@@ -42,8 +53,8 @@ type SliceGraphQLLike<TSliceType extends string = string> = {
  * @typeParam SliceType - Type name of the Slice.
  */
 type SliceLike<TSliceType extends string = string> =
-	| Slice<TSliceType>
-	| SliceGraphQLLike<TSliceType>;
+	| SliceLikeRestV2<TSliceType>
+	| SliceLikeGraphQL<TSliceType>;
 
 /**
  * A looser version of the `SliceZone` type from `@prismicio/client` using
@@ -101,7 +112,7 @@ type SliceMapperArgs<
 	// union of Slice types, it would include TSlice. This causes TypeScript to
 	// throw a compilation error.
 	slices: SliceZoneLike<
-		TSlice extends SliceGraphQLLike ? SliceGraphQLLike : Slice
+		TSlice extends SliceLikeGraphQL ? SliceLikeGraphQL : SliceLikeRestV2
 	>;
 
 	/**
@@ -171,7 +182,7 @@ type MapSliceLike<
 	TMappers extends Mappers,
 > = TSliceLike extends Slice
 	? TSliceLike["slice_type"] extends keyof TMappers
-		? Slice<TSliceLike["slice_type"]> &
+		? SliceLikeRestV2<TSliceLike["slice_type"]> &
 				MappedSliceLike &
 				Awaited<
 					ReturnType<
@@ -179,9 +190,9 @@ type MapSliceLike<
 					>
 				>
 		: TSliceLike
-	: TSliceLike extends SliceGraphQLLike
+	: TSliceLike extends SliceLikeGraphQL
 	? TSliceLike["type"] extends keyof TMappers
-		? SliceGraphQLLike<TSliceLike["type"]> &
+		? SliceLikeGraphQL<TSliceLike["type"]> &
 				MappedSliceLike &
 				Awaited<
 					ReturnType<ResolveLazyMapperModule<TMappers[TSliceLike["type"]]>>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes `unstable_mapSliceZone()`'s return type by only including the following necessary fields:

- `id` (optional)
- `slice_type` (for Rest API V2 Slices)
- `type` (for GraphQL Slices)

Before this PR, `primary`, `items`, etc. from the main `Slice` type were included in each Slice's return type, which is not always going to be the case.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
