### PR TITLE
fix: only use active preview refs

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -6,6 +6,7 @@ import { findMasterRef } from "./lib/findMasterRef";
 import { findRefByID } from "./lib/findRefByID";
 import { findRefByLabel } from "./lib/findRefByLabel";
 import { getPreviewCookie } from "./lib/getPreviewCookie";
+import { isActivePreviewCookie } from "./lib/isActivePreviewCookie";
 import { minifyGraphQLQuery } from "./lib/minifyGraphQLQuery";
 import { someTagsFilter } from "./lib/someTagsFilter";
 import { typeFilter } from "./lib/typeFilter";
@@ -1748,7 +1749,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 				previewRef = getPreviewCookie(cookieJar);
 			}
 
-			if (previewRef) {
+			if (previewRef && isActivePreviewCookie(previewRef)) {
 				return previewRef;
 			}
 		}

--- a/src/lib/isActivePreviewCookie.ts
+++ b/src/lib/isActivePreviewCookie.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Imports for @link references:
+import type { getPreviewCookie } from "./getPreviewCookie";
+
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+/**
+ * Returns whether or not a preview cookie represents an active one.
+ *
+ * @param cookie - The preview cookie value from {@link getPreviewCookie}
+ *
+ * @returns Whether or not the preview cookie represents an active previe.
+ */
+export const isActivePreviewCookie = (cookie: string): boolean => {
+	// An active cookie looks like this (URL encoded):
+	// 	{
+	// 		"_tracker": "abc123",
+	// 		"example-prismic-repo.prismic.io": {
+	// 			preview: "https://example-prismic-repo.prismic.io/previews/abc:123?websitePreviewId=xyz"
+	// 		}
+	// 	}
+	return /\.prismic\.io/.test(cookie);
+};

--- a/test/__fixtures__/previewRef.ts
+++ b/test/__fixtures__/previewRef.ts
@@ -1,0 +1,5 @@
+export const previewRef = {
+	active:
+		"{%22_tracker%22:%22h5OnhcUc%22%2C%22200629-sms-hoy.prismic.io%22:{%22preview%22:%22https://200629-sms-hoy.prismic.io/previews/ZInPGhIAACMASOcW:ZInUVxIAACQASP7j?websitePreviewId=ZGJDMREAACcA3up1%22}}",
+	inactive: "io.prismic.preview={%22_tracker%22:%22L0NuZuQh%22}",
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
By default, the client automatically tries to fetch previewed content by using the preview cookie as a ref when one is available. However, in some cases, the preview cookie is present, but in an inactive state, leading to unexpected behavior.

The preview cookie can be in an inactive state when you're on your Prismic website, logged in to Prismic, but outside of a preview session: the toolbar loads, and sets an inactive preview cookie.

<details>
<summary>Inactive preview cookie example</summary>

![image](https://github.com/prismicio/prismic-client/assets/25330882/8498adf0-b687-4567-ae82-a96c7b8b62f4)

</details>

When the preview cookie is available, but in this state, it is still picked up by the client, as demonstrated in this Replit: https://replit.com/@lihbr/prismicioprismic-client309#index.js

<details>
<summary>Replit logs</summary>

![image](https://github.com/prismicio/prismic-client/assets/25330882/e4e682d4-6e9d-4cb7-985c-f808c230e681)

</details>

When the client uses this inactive preview cookie as a ref to query the API, the API falls back to the current master ref (odd, but alright).

This might sound convenient, however, because Cloudflare caches requests based on their URL, and because the master ref is *implicit* in this calls, this means subsequent API calls will always return the same, cached, response from the master ref that was used to build it. This means the content will be out of date as soon as a new master ref is available (i.e. something gets published)

---

This PR fixes that by validating that the preview cookie is in an active state using the solution currently used by `@prismicio/next`: https://github.com/prismicio/prismic-next/blob/5c712675a14f6f504fe7914a73ceecb7ca430e4f/src/enableAutoPreviews.ts#L106-L122

This works OK, but has some corner cases:
- Only works for `.prismic.io` previews, doesn't work on staging (`.wroom.io` I assume, but the toolbar might be weird)
- Only works if you're only relying on one Prismic repository to build your website, might have unexpected behaviors if you're fetching data from two different Prismic repositories

A better solution would be to check for the key belonging to the repository the client instance is connected to, for it to be present and valid. However, checking for the repository name as a key in the preview cookie object is tough:
- We don't always have the repository name (we work internally with repository endpoints)
- We can't infer it safely (user might proxy their repository endpoint, or whatever)

So, I don't know...
- is the current solution good enough 🤷‍♀️
- should we try to add some more assertions 🤷‍♀️

<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Resolves: https://github.com/nuxt-modules/prismic/issues/198

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
