### PR TITLE
docs: Updated tags and oauth_token definitions in repository.ts

### DIFF
--- a/src/types/api/repository.ts
+++ b/src/types/api/repository.ts
@@ -52,7 +52,9 @@ export interface Repository {
 	 */
 	oauth_initiate: string;
 
-	// TODO: Describe this field
+	/**
+	 * The token used for the OAuth process for the repository.
+	 */
 	oauth_token: string;
 
 	/**

--- a/src/types/api/repository.ts
+++ b/src/types/api/repository.ts
@@ -34,7 +34,9 @@ export interface Repository {
 	types: Record<string, string>;
 
 	/**
-	 * A list of tags for the repository.
+	 * @deprecated Tags are only available in the forms object.
+	 * 
+	 * @see More details in the blog post "A change to how the Prismic API handles tags": {@link https://prismic.io/blog/a-change-to-how-the-prismic-api-handles-tags}
 	 */
 	tags: string[];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description
- Added a definition for `oauth_token` in `src/types/api/repository.ts`
- Updated `tags` definition in `src/types/api/repository.ts` to be deprecated, mentioned the new location, and linked to the relevant [blog post](https://prismic.io/blog/a-change-to-how-the-prismic-api-handles-tags) outlining the changes.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [ ] All new and existing tests are passing.