### PR TITLE
fix: support special characters in filters

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -19,7 +19,7 @@ const formatValue = (
 	}
 
 	if (typeof value === "string") {
-		return `"${value}"`;
+		return `"${value.replace(/"/g, '\\"')}"`;
 	}
 
 	if (value instanceof Date) {

--- a/test/filter-any.test.ts
+++ b/test/filter-any.test.ts
@@ -13,6 +13,11 @@ testFilter(
 );
 
 testFilter(
+	'[any(my.product.description, ["\\"quote\\""])]',
+	prismic.filter.any("my.product.description", ['"quote"']),
+);
+
+testFilter(
 	"[any(my.product.restock_date, [1600000000000, 1700000000000])]",
 	prismic.filter.any("my.product.restock_date", [
 		new Date(1600000000000),

--- a/test/filter-at.test.ts
+++ b/test/filter-at.test.ts
@@ -13,6 +13,11 @@ testFilter(
 );
 
 testFilter(
+	'[at(my.product.description, "\\"quote\\"")]',
+	prismic.filter.at("my.product.description", '"quote"'),
+);
+
+testFilter(
 	"[at(my.product.price, 50)]",
 	prismic.filter.at("my.product.price", 50),
 );

--- a/test/filter-fulltext.test.ts
+++ b/test/filter-fulltext.test.ts
@@ -16,3 +16,8 @@ testFilter(
 	'[fulltext(my.product.title, "phone")]',
 	prismic.filter.fulltext("my.product.title", "phone"),
 );
+
+testFilter(
+	'[fulltext(my.product.description, "\\"quote\\"")]',
+	prismic.filter.fulltext("my.product.description", '"quote"'),
+);

--- a/test/filter-in.test.ts
+++ b/test/filter-in.test.ts
@@ -11,3 +11,8 @@ testFilter(
 	'[in(my.page.uid, ["myuid1", "myuid2"])]',
 	prismic.filter.in("my.page.uid", ["myuid1", "myuid2"]),
 );
+
+testFilter(
+	'[in(my.product.description, ["\\"quote\\""])]',
+	prismic.filter.in("my.product.description", ['"quote"']),
+);

--- a/test/filter-not.test.ts
+++ b/test/filter-not.test.ts
@@ -13,6 +13,11 @@ testFilter(
 );
 
 testFilter(
+	'[not(my.product.description, "\\"quote\\"")]',
+	prismic.filter.not("my.product.description", '"quote"'),
+);
+
+testFilter(
 	"[not(my.product.price, 50)]",
 	prismic.filter.not("my.product.price", 50),
 );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where special charcters, such as `"`, were not escaped in filters.

**Before this PR (note the double `""`)**:

```ts
import { filter } from "@prismicio/client";

filter.fulltext("my.page.key_text_field", '"quote"');
// => [fulltext(my.page.key_text_field, ""quote"")]
```

**After this PR (note the escaped `"`)**:

```ts
import { filter } from "@prismicio/client";

filter.fulltext("my.page.key_text_field", '"quote"');
// => [fulltext(my.page.key_text_field, "\"quote\"")]
```

Fixes #314

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦡
