### PR TITLE
fix: throw `NotFoundError` when a document cannot be found

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -664,7 +664,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 			return firstResult;
 		}
 
-		throw new PrismicError("No documents were returned", url, undefined);
+		throw new NotFoundError("No documents were returned", url, undefined);
 	}
 
 	/**

--- a/test/client-getFirst.test.ts
+++ b/test/client-getFirst.test.ts
@@ -90,7 +90,7 @@ it("throws if no documents were returned", async (ctx) => {
 		/no documents were returned/i,
 	);
 	await expect(() => client.getFirst()).rejects.toThrowError(
-		prismic.PrismicError,
+		prismic.NotFoundError,
 	);
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes `getFirst()` and all dependent methods, including `getByUID()` and `getByID()`, by throwing a `NotFoundError` when a matching document is not found.

`NotFoundError` is a subclass of `PrismicError`, retaining compatibility with `instanceof PrismicError`.

**Before**:

```ts
import { createClient } from "@prismicio/client";

const client = createClient("example-prismic-repo");
await client.getByUID("page", "non-existent");
// => throws PrismicError
```

**After**:

```ts
import { createClient } from "@prismicio/client";

const client = createClient("example-prismic-repo");
await client.getByUID("page", "non-existent");
// => throws NotFoundError
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦁
