### PR TITLE
feat: automatically retry rate-limited requests

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -52,6 +52,15 @@ export const REPOSITORY_CACHE_TTL = 5000;
 export const GET_ALL_QUERY_DELAY = 500;
 
 /**
+ * The number of milliseconds to wait before retrying a rate-limited `fetch()`
+ * request (429 response code). The default value is only used if the response
+ * does not include a `retry-after` header.
+ *
+ * The API allows up to 200 requests per second.
+ */
+const DEFUALT_RETRY_AFTER_MS = 1000;
+
+/**
  * Extracts one or more Prismic document types that match a given Prismic
  * document type. If no matches are found, no extraction is performed and the
  * union of all provided Prismic document types are returned.
@@ -120,8 +129,16 @@ export interface RequestInitLike extends Pick<RequestInit, "cache"> {
  */
 export interface ResponseLike {
 	status: number;
+	headers: HeadersLike;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	json(): Promise<any>;
+}
+
+/**
+ * THe minimum required properties from Headers.
+ */
+export interface HeadersLike {
+	get(name: string): string | null;
 }
 
 /**
@@ -342,6 +359,7 @@ type ResolvePreviewArgs<LinkResolverReturnType> = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type FetchJobResult<TJSON = any> = {
 	status: number;
+	headers: HeadersLike;
 	json: TJSON;
 };
 
@@ -1839,6 +1857,7 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 
 					return {
 						status: res.status,
+						headers: res.headers,
 						json,
 					};
 				})
@@ -1895,6 +1914,25 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 					url,
 					undefined,
 				);
+			}
+
+			// Too Many Requests
+			// - Exceeded the maximum number of requests per second
+			case 429: {
+				const parsedRetryAfter = Number(res.headers.get("retry-after"));
+				const delay = Number.isNaN(parsedRetryAfter)
+					? DEFUALT_RETRY_AFTER_MS
+					: parsedRetryAfter;
+
+				return await new Promise((resolve, reject) => {
+					setTimeout(async () => {
+						try {
+							resolve(await this.fetch(url, params));
+						} catch (error) {
+							reject(error);
+						}
+					}, delay);
+				});
 			}
 		}
 

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -52,9 +52,9 @@ export const REPOSITORY_CACHE_TTL = 5000;
 export const GET_ALL_QUERY_DELAY = 500;
 
 /**
- * The number of milliseconds to wait before retrying a rate-limited `fetch()`
- * request (429 response code). The default value is only used if the response
- * does not include a `retry-after` header.
+ * The default number of milliseconds to wait before retrying a rate-limited
+ * `fetch()` request (429 response code). The default value is only used if the
+ * response does not include a `retry-after` header.
  *
  * The API allows up to 200 requests per second.
  */
@@ -135,7 +135,7 @@ export interface ResponseLike {
 }
 
 /**
- * THe minimum required properties from Headers.
+ * The minimum required properties from Headers.
  */
 export interface HeadersLike {
 	get(name: string): string | null;

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -810,12 +810,7 @@ it("throws if a non-2xx response is returned even after retrying", async (ctx) =
 	 */
 	const testTolerance = 100;
 
-	const queryResponse = prismicM.api.query({ seed: ctx.task.name });
-
-	mockPrismicRestAPIV2({
-		ctx,
-		queryResponse,
-	});
+	mockPrismicRestAPIV2({ ctx });
 
 	const client = createTestClient();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds automatic retry support when Prismic Rest API V2 returns a "429: Too many requests" error response.

The 429 error response can be returned if the API rate limit is exceeded. As of this PR, **the API has a limit of 200 requests per second**.

`@prismicio/client` will automatically retry those requests after enough time has ellapsed to avoid the rate limit. The retry will be transparent from client code, except for the extra wait time.

Code using `@prismicio/client` does not need to change to take advantage of the automatic retry feature.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🦔
