### PR TITLE
fix: support expired preview token and repository not found API error

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -18,6 +18,7 @@ import type { PrismicDocument } from "./types/value/document";
 import { ForbiddenError } from "./errors/ForbiddenError";
 import { NotFoundError } from "./errors/NotFoundError";
 import { ParsingError } from "./errors/ParsingError";
+import { PreviewTokenExpiredError } from "./errors/PreviewTokenExpired";
 import { PrismicError } from "./errors/PrismicError";
 import { RefExpiredError } from "./errors/RefExpiredError";
 import { RefNotFoundError } from "./errors/RefNotFoundError";
@@ -1912,15 +1913,26 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 			// - Incorrect repository name (this response has an empty body)
 			// - Ref does not exist
 			case 404: {
-				if (res.json && res.json.type === "api_notfound_error") {
+				if (res.json === undefined) {
+					throw new NotFoundError(
+						`Prismic repository not found. Check that "${this.endpoint}" is pointing to the correct repository.`,
+						url,
+						undefined,
+					);
+				}
+
+				if (res.json.type === "api_notfound_error") {
 					throw new RefNotFoundError(res.json.message, url, res.json);
 				}
 
-				throw new NotFoundError(
-					`Prismic repository not found. Check that "${this.endpoint}" is pointing to the correct repository.`,
-					url,
-					undefined, // res.json is empty
-				);
+				if (
+					res.json.type === "api_security_error" &&
+					/preview token.*expired/i.test(res.json.message)
+				) {
+					throw new PreviewTokenExpiredError(res.json.message, url, res.json);
+				}
+
+				throw new NotFoundError(res.json.message, url, res.json);
 			}
 
 			// Gone

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -22,6 +22,7 @@ import { PreviewTokenExpiredError } from "./errors/PreviewTokenExpired";
 import { PrismicError } from "./errors/PrismicError";
 import { RefExpiredError } from "./errors/RefExpiredError";
 import { RefNotFoundError } from "./errors/RefNotFoundError";
+import { RepositoryNotFoundError } from "./errors/RepositoryNotFoundError";
 
 import { LinkResolverFunction, asLink } from "./helpers/asLink";
 
@@ -1912,9 +1913,10 @@ export class Client<TDocuments extends PrismicDocument = PrismicDocument> {
 			// Not Found
 			// - Incorrect repository name (this response has an empty body)
 			// - Ref does not exist
+			// - Preview token is expired
 			case 404: {
 				if (res.json === undefined) {
-					throw new NotFoundError(
+					throw new RepositoryNotFoundError(
 						`Prismic repository not found. Check that "${this.endpoint}" is pointing to the correct repository.`,
 						url,
 						undefined,

--- a/src/errors/PreviewTokenExpired.ts
+++ b/src/errors/PreviewTokenExpired.ts
@@ -1,0 +1,12 @@
+import { ForbiddenError } from "./ForbiddenError";
+
+type PreviewTokenExpiredErrorAPIResponse = {
+	type: "api_security_error";
+	message: string;
+};
+
+// This error extends `ForbiddenError` for backwards compatibility.
+// TODO: Extend this error from `PrismicError` in v8.
+export class PreviewTokenExpiredError<
+	TResponse = PreviewTokenExpiredErrorAPIResponse,
+> extends ForbiddenError<TResponse> {}

--- a/src/errors/RepositoryNotFoundError.ts
+++ b/src/errors/RepositoryNotFoundError.ts
@@ -1,0 +1,5 @@
+import { NotFoundError } from "./NotFoundError";
+
+export class RepositoryNotFoundError<
+	TResponse = undefined,
+> extends NotFoundError<TResponse> {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export { RefNotFoundError } from "./errors/RefNotFoundError";
 export { RefExpiredError } from "./errors/RefExpiredError";
 export { PreviewTokenExpiredError } from "./errors/PreviewTokenExpired";
 export { ParsingError } from "./errors/ParsingError";
+export { RepositoryNotFoundError } from "./errors/RepositoryNotFoundError";
 
 //=============================================================================
 // Types - Types representing Prismic content, models, and API payloads.

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ export { ForbiddenError } from "./errors/ForbiddenError";
 export { NotFoundError } from "./errors/NotFoundError";
 export { RefNotFoundError } from "./errors/RefNotFoundError";
 export { RefExpiredError } from "./errors/RefExpiredError";
+export { PreviewTokenExpiredError } from "./errors/PreviewTokenExpired";
 export { ParsingError } from "./errors/ParsingError";
 
 //=============================================================================

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -669,7 +669,7 @@ it("throws PrismicError if response is not JSON", async (ctx) => {
 	await expect(() => client.get()).rejects.toThrowError(prismic.PrismicError);
 });
 
-it("throws NotFoundError if repository does not exist", async (ctx) => {
+it("throws RepositoryNotFoundError if repository does not exist", async (ctx) => {
 	const client = createTestClient();
 
 	ctx.server.use(
@@ -681,7 +681,9 @@ it("throws NotFoundError if repository does not exist", async (ctx) => {
 	await expect(() => client.get()).rejects.toThrowError(
 		/repository not found/i,
 	);
-	await expect(() => client.get()).rejects.toThrowError(prismic.NotFoundError);
+	await expect(() => client.get()).rejects.toThrowError(
+		prismic.RepositoryNotFoundError,
+	);
 });
 
 it("throws RefNotFoundError if ref does not exist", async (ctx) => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -738,6 +738,60 @@ it("throws RefExpiredError if ref is expired", async (ctx) => {
 	);
 });
 
+it("throws PreviewTokenExpiredError if preview token is expired", async (ctx) => {
+	const queryResponse = {
+		type: "api_security_error",
+		message: "This preview token has expired",
+		oauth_initiate: "https://qwerty.prismic.io/auth",
+		oauth_token: "https://qwerty.prismic.io/auth/token",
+	};
+
+	mockPrismicRestAPIV2({ ctx });
+
+	const client = createTestClient();
+
+	const queryEndpoint = new URL(
+		"./documents/search",
+		`${client.endpoint}/`,
+	).toString();
+
+	ctx.server.use(
+		msw.rest.get(queryEndpoint, (_req, res, ctx) => {
+			return res(ctx.status(404), ctx.json(queryResponse));
+		}),
+	);
+
+	await expect(() => client.get()).rejects.toThrowError(queryResponse.message);
+	await expect(() => client.get()).rejects.toThrowError(
+		prismic.PreviewTokenExpiredError,
+	);
+});
+
+it("throws NotFoundError if the 404 error is unknown", async (ctx) => {
+	const queryResponse = {
+		type: "unknown_type",
+		message: "message",
+	};
+
+	mockPrismicRestAPIV2({ ctx });
+
+	const client = createTestClient();
+
+	const queryEndpoint = new URL(
+		"./documents/search",
+		`${client.endpoint}/`,
+	).toString();
+
+	ctx.server.use(
+		msw.rest.get(queryEndpoint, (_req, res, ctx) => {
+			return res(ctx.status(404), ctx.json(queryResponse));
+		}),
+	);
+
+	await expect(() => client.get()).rejects.toThrowError(queryResponse.message);
+	await expect(() => client.get()).rejects.toThrowError(prismic.NotFoundError);
+});
+
 it("retries after `retry-after` milliseconds if response code is 429", async (ctx) => {
 	const retryAfter = 200; // ms
 	/**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for two errors in response to the Prismic Document API.

- **`PreviewTokenExpiredError`**: Thrown when a query's preview token (used as a ref) is expired. This error extends from `ForbiddenError` for consistency with [the other ref-related errors](https://github.com/prismicio/prismic-client/pull/327).
- **`RepositoryNotFoundError`**: Thrown when a Prismic repository does not exist. This error was previously thrown as `NotFoundError`. Thus, the new error extends from `NotFoundError` to ensure this change is non-breaking.

The new errors will extend from PrismicError in a future major version for better semantics.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐤
