### PR TITLE
feat: support image captions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 			},
 			"devDependencies": {
 				"@prismicio/mock": "^0.3.1",
-				"@prismicio/types-internal": "2.3.0",
+				"@prismicio/types-internal": "^2.4.0-alpha.1",
 				"@size-limit/preset-small-lib": "^9.0.0",
 				"@trivago/prettier-plugin-sort-imports": "^4.2.0",
 				"@typescript-eslint/eslint-plugin": "^6.7.4",
@@ -1008,9 +1008,9 @@
 			}
 		},
 		"node_modules/@prismicio/types-internal": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-2.3.0.tgz",
-			"integrity": "sha512-TzHLJkq698csns1TkS9EixAONuni6Me9a6WDpAG7lcgKoN+qeefIwddGap8Vn+v/zXNUBi1sDswGMG40TEwzHA==",
+			"version": "2.4.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-2.4.0-alpha.1.tgz",
+			"integrity": "sha512-rL9G98waiTJJCryKJnxZBiH+cDlYN+Ugr+3DL3xreqOQsNhxH+tIBqJybTdKkNNO+oi9aEZG5WY3zQlYwwB+lg==",
 			"dev": true,
 			"dependencies": {
 				"monocle-ts": "^2.3.11",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 	},
 	"devDependencies": {
 		"@prismicio/mock": "^0.3.1",
-		"@prismicio/types-internal": "2.3.0",
+		"@prismicio/types-internal": "^2.4.0-alpha.1",
 		"@size-limit/preset-small-lib": "^9.0.0",
 		"@trivago/prettier-plugin-sort-imports": "^4.2.0",
 		"@typescript-eslint/eslint-plugin": "^6.7.4",

--- a/src/helpers/asImageWidthSrcSet.ts
+++ b/src/helpers/asImageWidthSrcSet.ts
@@ -4,7 +4,7 @@ import {
 	buildWidthSrcSet,
 } from "imgix-url-builder";
 
-import type { ImageFieldImage } from "../types/value/image";
+import type { ImageField, ImageFieldImage } from "../types/value/image";
 
 import * as isFilled from "./isFilled";
 
@@ -78,7 +78,7 @@ type AsImageWidthSrcSetConfig = Omit<BuildWidthSrcSetParams, "widths"> & {
  * @see Imgix URL parameters reference: https://docs.imgix.com/apis/rendering
  */
 export const asImageWidthSrcSet = <
-	Field extends ImageFieldImage | null | undefined,
+	Field extends ImageField | ImageFieldImage | null | undefined,
 >(
 	field: Field,
 	config: AsImageWidthSrcSetConfig = {},
@@ -91,16 +91,11 @@ export const asImageWidthSrcSet = <
 			// eslint-disable-next-line prefer-const
 			...imgixParams
 		} = config;
-		const {
-			url,
-			dimensions,
-			id: _id,
-			alt: _alt,
-			copyright: _copyright,
-			edit: _edit,
-			caption: _caption,
-			...responsiveViews
-		} = field;
+		const { url, dimensions } = field;
+
+		const responsiveViews = Object.values(field).filter(
+			isFilled.imageThumbnail,
+		);
 
 		// The Prismic Rest API will always return thumbnail values if
 		// the base size is filled.

--- a/src/helpers/asImageWidthSrcSet.ts
+++ b/src/helpers/asImageWidthSrcSet.ts
@@ -98,6 +98,7 @@ export const asImageWidthSrcSet = <
 			alt: _alt,
 			copyright: _copyright,
 			edit: _edit,
+			caption: _caption,
 			...responsiveViews
 		} = field;
 

--- a/src/types/model/image.ts
+++ b/src/types/model/image.ts
@@ -33,5 +33,6 @@ export interface CustomTypeModelImageField<
 		label?: string | null;
 		constraint?: CustomTypeModelImageConstraint;
 		thumbnails?: readonly CustomTypeModelImageThumbnail<ThumbnailNames>[];
+		allowCaption?: boolean;
 	};
 }

--- a/src/types/value/image.ts
+++ b/src/types/value/image.ts
@@ -72,7 +72,11 @@ export type ImageField<
 		// editor experience.
 		State extends "filled"
 			? ImageFieldImage<State> &
-					Record<Extract<ThumbnailNames, string>, ImageFieldImage<State>>
+					Record<Extract<ThumbnailNames, string>, ImageFieldImage<State>> & {
+						caption: string | null;
+					}
 			: ImageFieldImage<State> &
-					Record<Extract<ThumbnailNames, string>, ImageFieldImage<State>>
+					Record<Extract<ThumbnailNames, string>, ImageFieldImage<State>> & {
+						caption?: null;
+					}
 	>;

--- a/test/helpers-asImagePixelDensitySrcSet.test.ts
+++ b/test/helpers-asImagePixelDensitySrcSet.test.ts
@@ -19,6 +19,7 @@ it("returns an image field pixel-density-based srcset with [1, 2, 3] pxiel densi
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 400, height: 300 },
 	};
 
@@ -43,6 +44,7 @@ it("supports custom pixel densities", () => {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 400, height: 300 },
 	};
 
@@ -71,6 +73,7 @@ it("applies given Imgix URL parameters", () => {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 400, height: 300 },
 	};
 

--- a/test/helpers-asImageSrc.test.ts
+++ b/test/helpers-asImageSrc.test.ts
@@ -19,6 +19,7 @@ it("returns an image field URL", () => {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 400, height: 300 },
 	};
 
@@ -37,6 +38,7 @@ it("applies given Imgix URL parameters", () => {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 400, height: 300 },
 	};
 

--- a/test/helpers-asImageWidthSrcSet.test.ts
+++ b/test/helpers-asImageWidthSrcSet.test.ts
@@ -19,6 +19,7 @@ it("returns an image field src and width-based srcset with [640, 750, 828, 1080,
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 400, height: 300 },
 	};
 
@@ -45,6 +46,7 @@ it("supports custom widths", () => {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 400, height: 300 },
 	};
 
@@ -73,6 +75,7 @@ it("applies given Imgix URL parameters", () => {
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 400, height: 300 },
 	};
 
@@ -103,6 +106,7 @@ it('if widths is "thumbnails", returns a srcset of responsive views if the field
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 1000, height: 800 },
 		foo: {
 			id: "id",
@@ -153,6 +157,7 @@ it('if widths is "thumbnails", but the field does not contain responsive views, 
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 1000, height: 800 },
 	};
 
@@ -179,6 +184,7 @@ it('if widths is not "thumbnails", but the field contains responsive views, uses
 		url: "https://images.prismic.io/qwerty/image.png?auto=compress%2Cformat",
 		alt: null,
 		copyright: null,
+		caption: null,
 		dimensions: { width: 1000, height: 800 },
 		foo: {
 			id: "id",

--- a/test/types/customType-image.types.ts
+++ b/test/types/customType-image.types.ts
@@ -74,6 +74,16 @@ expectType<prismic.CustomTypeModelImageField>({
 });
 
 /**
+ * Supports optional caption.
+ */
+expectType<prismic.CustomTypeModelImageField>({
+	type: prismic.CustomTypeModelFieldType.Image,
+	config: {
+		allowCaption: true,
+	},
+});
+
+/**
  * Supports custom thumbnail names.
  */
 expectType<prismic.CustomTypeModelImageField<"Foo">>({

--- a/test/types/fields-image.types.ts
+++ b/test/types/fields-image.types.ts
@@ -28,6 +28,7 @@ expectType<prismic.ImageField>({
 	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: "alt",
 	copyright: "copyright",
+	caption: "caption",
 });
 expectType<prismic.ImageField<never, "filled">>({
 	id: "id",
@@ -36,6 +37,7 @@ expectType<prismic.ImageField<never, "filled">>({
 	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: "alt",
 	copyright: "copyright",
+	caption: "caption",
 });
 expectType<prismic.ImageField<never, "empty">>({
 	// @ts-expect-error - Empty fields cannot contain a filled value.
@@ -50,6 +52,8 @@ expectType<prismic.ImageField<never, "empty">>({
 	alt: "alt",
 	// @ts-expect-error - Empty fields cannot contain a filled value.
 	copyright: "copyright",
+	// @ts-expect-error - Empty fields cannot contain a filled value.
+	caption: "caption",
 });
 
 /**
@@ -60,6 +64,7 @@ expectType<prismic.ImageField>({
 	dimensions: null,
 	alt: null,
 	copyright: null,
+	caption: null,
 });
 expectType<prismic.ImageField>({});
 expectType<prismic.ImageField<never, "empty">>({
@@ -67,6 +72,7 @@ expectType<prismic.ImageField<never, "empty">>({
 	dimensions: null,
 	alt: null,
 	copyright: null,
+	caption: null,
 });
 expectType<prismic.ImageField<never, "filled">>({
 	// @ts-expect-error - Filled fields cannot contain an empty value.
@@ -79,10 +85,11 @@ expectType<prismic.ImageField<never, "filled">>({
 	edit: null,
 	alt: null,
 	copyright: null,
+	caption: null,
 });
 
 /**
- * Allows null alt and copyright.
+ * Allows null alt, copyright, and caption.
  */
 expectType<prismic.ImageField>({
 	id: "id",
@@ -91,6 +98,7 @@ expectType<prismic.ImageField>({
 	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: null,
 	copyright: null,
+	caption: null,
 });
 
 /**
@@ -101,6 +109,7 @@ expectType<prismic.ImageField>({
 	dimensions: { width: 1, height: 1 },
 	alt: "alt",
 	copyright: "copyright",
+	caption: "caption",
 	// @ts-expect-error - No thumbnails are included by default.
 	Foo: {},
 });
@@ -115,6 +124,7 @@ expectType<prismic.ImageField<"Foo" | "Bar">>({
 	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: "alt",
 	copyright: "copyright",
+	caption: "caption",
 	Foo: {
 		id: "id",
 		url: "url",
@@ -145,6 +155,7 @@ expectType<prismic.ImageField<never>>({
 	dimensions: { width: 1, height: 1 },
 	alt: null,
 	copyright: null,
+	caption: null,
 	// @ts-expect-error - No thumbnails should be included when set to `never`.
 	Foo: {
 		url: "url",
@@ -169,6 +180,7 @@ expectType<prismic.ImageField<null>>({
 	dimensions: { width: 1, height: 1 },
 	alt: null,
 	copyright: null,
+	caption: null,
 	// @ts-expect-error - No thumbnails should be included when set to `null`.
 	Foo: {
 		url: "url",
@@ -191,6 +203,7 @@ expectType<prismic.ImageField>({
 	dimensions: { width: 1, height: 1 },
 	alt: "alt",
 	copyright: "copyright",
+	caption: "caption",
 	// @ts-expect-error - `"length"` shouldn't be available as a thumbnail name by default
 	length: {
 		url: "url",
@@ -206,6 +219,7 @@ expectType<prismic.ImageField<"length">>({
 	edit: { x: 0, y: 0, zoom: 1, background: "background" },
 	alt: "alt",
 	copyright: "copyright",
+	caption: "caption",
 	length: {
 		id: "id",
 		url: "url",
@@ -229,13 +243,11 @@ const _ImageFieldIsValidImageFieldImageExtendDebug: prismic.ImageFieldImage =
 	{} as prismic.ImageField;
 
 /**
- * ImageFieldImages are valid ImageField extends with no thumbnails.
+ * ImageFieldImages are not valid ImageField extends, even without thumbnails.
  */
-expectType<TypeOf<prismic.ImageField, prismic.ImageFieldImage>>(true);
-expectType<TypeOf<prismic.ImageField<never>, prismic.ImageFieldImage>>(true);
+expectType<TypeOf<prismic.ImageField, prismic.ImageFieldImage>>(false);
+expectType<TypeOf<prismic.ImageField<never>, prismic.ImageFieldImage>>(false);
 expectType<TypeOf<prismic.ImageField<"Foo">, prismic.ImageFieldImage>>(false);
 expectType<TypeOf<prismic.ImageField<"Foo" | "Bar">, prismic.ImageFieldImage>>(
 	false,
 );
-const _ImageFieldImageIsValidImageFieldExtendDebug: prismic.ImageField =
-	{} as prismic.ImageFieldImage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR adds support for image captions. It does this by:

- Add a boolean allowCaption config property to the Image widget.
- Add a caption property to ImageContent that holds string | null.
- Ensures the `caption` image property is not treated as a thumbnail in `asImageWidthSrcSet`.

The changes in this package mirror the changes in `@prismicio/types-internal`. See https://github.com/prismicio/prismic-types-internal/pull/69 for details.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
🦚
