### PR TITLE
fix: type error in `mapSliceZone`

### DIFF
--- a/src/helpers/mapSliceZone.ts
+++ b/src/helpers/mapSliceZone.ts
@@ -19,7 +19,7 @@ type AnyFunction = (...args: any[]) => any;
  *
  * @typeParam Slice - The Slice from which the type will be extracted.
  */
-type ExtractSliceType<TSlice extends SliceLike> = TSlice extends Slice
+type ExtractSliceType<TSlice extends SliceLike> = TSlice extends SliceLikeRestV2
 	? TSlice["slice_type"]
 	: TSlice extends SliceLikeGraphQL
 	? TSlice["type"]
@@ -175,7 +175,7 @@ type MapSliceLike<
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	TSliceLike extends SliceLike<any>,
 	TSliceMappers extends SliceMappers<
-		SliceLike<ExtractSliceType<TSliceLike>>,
+		TSliceLike,
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		any
 	>,
@@ -232,13 +232,7 @@ export function mapSliceZone<
 	sliceZone: SliceZoneLike<TSliceLike>,
 	mappers: TSliceMappers,
 	context?: TContext,
-): Promise<
-	MapSliceLike<
-		TSliceLike,
-		// @ts-expect-error - I don't know how to fix this type
-		TSliceMappers
-	>[]
-> {
+): Promise<MapSliceLike<TSliceLike, TSliceMappers>[]> {
 	return Promise.all(
 		sliceZone.map(async (slice, index, slices) => {
 			const isRestSliceType = "slice_type" in slice;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a type error in `mapSliceZone`. The error was ignored via `// @ts-expect-error` in the source code, but the compiled output removed the comment. Thus, consumers that check the types of the installed package would throw a type error.

The typings have been fixed so `// @ts-expect-error` is no longer used.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
