### PR TITLE
feat: add support for text in links for 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
 				"imgix-url-builder": "^0.0.5"
 			},
 			"devDependencies": {
-				"@prismicio/mock": "^0.3.7",
-				"@prismicio/types-internal": "^2.6.0",
+				"@prismicio/mock": "^0.3.8-alpha.1",
+				"@prismicio/types-internal": "2.7.0-alpha.2",
 				"@size-limit/preset-small-lib": "^11.1.4",
 				"@trivago/prettier-plugin-sort-imports": "^4.3.0",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -1198,11 +1198,10 @@
 			}
 		},
 		"node_modules/@prismicio/client": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.8.1.tgz",
-			"integrity": "sha512-L1pwiBHy4X2KB4ayliTbTB6wbgRDkspyQ+R/czVqNON9R5cU1pAHxSxK8/GVbukKrEHNAaZHlAfOT3rzSJJGBw==",
+			"version": "7.9.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@prismicio/client/-/client-7.9.0-alpha.2.tgz",
+			"integrity": "sha512-Y4Ti7XoJ57Rk2AkhI0UBxg3f2+wGr4ZwGfr82bFbmY9CCAUXQ+aN8cl3nUSCUafhRyJTcqWSty52D8RKvseY4g==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
 				"imgix-url-builder": "^0.0.5"
@@ -1212,11 +1211,10 @@
 			}
 		},
 		"node_modules/@prismicio/mock": {
-			"version": "0.3.7",
-			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.3.7.tgz",
-			"integrity": "sha512-aXNSWMVTSanVSVxgIw0q+1YHj33Yv9GjVX9MuWBIQddf0dmDSMSiLEmDG1LSCgWq2cpukLMf/4eSo3P4dwG/kQ==",
+			"version": "0.3.8-alpha.1",
+			"resolved": "https://registry.npmjs.org/@prismicio/mock/-/mock-0.3.8-alpha.1.tgz",
+			"integrity": "sha512-dzVdgvNW0pvg5mFBL0hudezsRAzPwO0aL3tG5bg5PRYxmx1uQK2knZfqqtjPmaSZCAozDTZG+wHJ/04OsjeBcQ==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
 				"change-case": "^5.4.4"
 			},
@@ -1228,11 +1226,10 @@
 			}
 		},
 		"node_modules/@prismicio/types-internal": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-2.6.0.tgz",
-			"integrity": "sha512-79ZiocAFJ4pjox07I/iX8qpvLuRunoVR+qKhY6a6SuNwBylqMgNDNN5+buEjUdIAW1gR7Il6P6bJa5aAwmvXWA==",
+			"version": "2.7.0-alpha.2",
+			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-2.7.0-alpha.2.tgz",
+			"integrity": "sha512-7iyTtDGnfblteA0zDUBIXY2FQ9ipY4XeY3u9MtIGFzjBUlpHbL1Phgff2OZscbf3LyJm3Cy2JOqd+ae78hrMGg==",
 			"dev": true,
-			"license": "Apache-2.0",
 			"dependencies": {
 				"monocle-ts": "^2.3.11",
 				"newtype-ts": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
 		"imgix-url-builder": "^0.0.5"
 	},
 	"devDependencies": {
-		"@prismicio/mock": "^0.3.7",
-		"@prismicio/types-internal": "^2.6.0",
+		"@prismicio/mock": "^0.3.8-alpha.1",
+		"@prismicio/types-internal": "2.7.0-alpha.2",
 		"@size-limit/preset-small-lib": "^11.1.4",
 		"@trivago/prettier-plugin-sort-imports": "^4.3.0",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -111,5 +111,10 @@
 	},
 	"publishConfig": {
 		"access": "public"
+	},
+	"overrides": {
+		"@prismicio/mock": {
+			"@prismicio/client": "7.9.0-alpha.2"
+		}
 	}
 }

--- a/src/helpers/asLinkAttrs.ts
+++ b/src/helpers/asLinkAttrs.ts
@@ -22,6 +22,7 @@ type AsLinkAttrsConfigRelArgs<
 		| undefined
 	isExternal: boolean
 	target?: string
+	text?: string
 }
 
 export type AsLinkAttrsConfig<
@@ -58,11 +59,13 @@ type AsLinkAttrsReturnType<
 				| NonNullable<AsLinkReturnType<LinkResolverFunctionReturnType, Field>>
 				| undefined
 			target?: string
+			text?: string
 			rel?: string
 		}
 	: {
 			href?: undefined
 			target?: undefined
+			text?: undefined
 			rel?: undefined
 		}
 
@@ -101,15 +104,11 @@ export const asLinkAttrs = <
 ): AsLinkAttrsReturnType<LinkResolverFunctionReturnType> => {
 	if (
 		linkFieldOrDocument &&
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore - Bug in TypeScript 4.9: https://github.com/microsoft/TypeScript/issues/51501
 		("link_type" in linkFieldOrDocument
 			? isFilledLink(linkFieldOrDocument)
 			: linkFieldOrDocument)
 	) {
 		const target =
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore - Bug in TypeScript 4.9: https://github.com/microsoft/TypeScript/issues/51501
 			"target" in linkFieldOrDocument ? linkFieldOrDocument.target : undefined
 
 		const rawHref = asLink(linkFieldOrDocument, config.linkResolver)
@@ -124,10 +123,14 @@ export const asLinkAttrs = <
 				? "noreferrer"
 				: undefined
 
+		const text =
+			"text" in linkFieldOrDocument ? linkFieldOrDocument.text : undefined
+
 		return {
 			href,
 			target,
 			rel: rel == null ? undefined : rel,
+			text,
 		}
 	}
 

--- a/test/helpers-asLinkAttrs.test.ts
+++ b/test/helpers-asLinkAttrs.test.ts
@@ -39,11 +39,13 @@ it("resolves a link to document field with route resolver", (ctx) => {
 		href: field.url,
 		target: undefined,
 		rel: undefined,
+		text: undefined,
 	})
 	expect(asLinkAttrs(field, { linkResolver: () => "/linkResolver" })).toEqual({
 		href: "/linkResolver",
 		target: undefined,
 		rel: undefined,
+		text: undefined,
 	})
 })
 
@@ -55,11 +57,13 @@ it("resolves a link to document field without route resolver", (ctx) => {
 		href: undefined,
 		target: undefined,
 		rel: undefined,
+		text: undefined,
 	})
 	expect(asLinkAttrs(field, { linkResolver: () => "/linkResolver" })).toEqual({
 		href: "/linkResolver",
 		target: undefined,
 		rel: undefined,
+		text: undefined,
 	})
 })
 
@@ -70,11 +74,13 @@ it("resolves a link to web field", (ctx) => {
 		href: field.url,
 		target: undefined,
 		rel: "noreferrer",
+		text: undefined,
 	})
 	expect(asLinkAttrs(field, { linkResolver: () => "/linkResolver" })).toEqual({
 		href: field.url,
 		target: undefined,
 		rel: "noreferrer",
+		text: undefined,
 	})
 })
 
@@ -85,11 +91,30 @@ it("returns correct target when field has a target", (ctx) => {
 		href: field.url,
 		target: field.target,
 		rel: "noreferrer",
+		text: undefined,
 	})
 	expect(asLinkAttrs(field, { linkResolver: () => "/linkResolver" })).toEqual({
 		href: field.url,
 		target: field.target,
 		rel: "noreferrer",
+		text: undefined,
+	})
+})
+
+it("returns correct text when field has text", (ctx) => {
+	const field = ctx.mock.value.link({ type: "Web", withText: true })
+
+	expect(asLinkAttrs(field)).toEqual({
+		href: field.url,
+		target: undefined,
+		rel: "noreferrer",
+		text: field.text,
+	})
+	expect(asLinkAttrs(field, { linkResolver: () => "/linkResolver" })).toEqual({
+		href: field.url,
+		target: undefined,
+		rel: "noreferrer",
+		text: field.text,
 	})
 })
 
@@ -100,11 +125,64 @@ it("resolves a link to media field", (ctx) => {
 		href: field.url,
 		target: undefined,
 		rel: "noreferrer",
+		text: undefined,
 	})
 	expect(asLinkAttrs(field, { linkResolver: () => "/linkResolver" })).toEqual({
 		href: field.url,
 		target: undefined,
 		rel: "noreferrer",
+		text: undefined,
+	})
+})
+
+it("returns correct text when a link to media field has display text", (ctx) => {
+	const field = ctx.mock.value.link({ type: "Media", withText: true })
+
+	expect(asLinkAttrs(field)).toEqual({
+		href: field.url,
+		target: undefined,
+		rel: "noreferrer",
+		text: field.text,
+	})
+	expect(asLinkAttrs(field, { linkResolver: () => "/linkResolver" })).toEqual({
+		href: field.url,
+		target: undefined,
+		rel: "noreferrer",
+		text: field.text,
+	})
+})
+
+it("resolves a content relationship field", (ctx) => {
+	const field = ctx.mock.value.link({ type: "Document" })
+
+	expect(asLinkAttrs(field)).toEqual({
+		href: field.url,
+		target: undefined,
+		rel: "noreferrer",
+		text: undefined,
+	})
+	expect(asLinkAttrs(field, { linkResolver: () => "/linkResolver" })).toEqual({
+		href: "/linkResolver",
+		target: undefined,
+		rel: undefined,
+		text: undefined,
+	})
+})
+
+it("returns correct text when a content relationship field has display text", (ctx) => {
+	const field = ctx.mock.value.link({ type: "Document", withText: true })
+
+	expect(asLinkAttrs(field)).toEqual({
+		href: field.url,
+		target: undefined,
+		rel: "noreferrer",
+		text: field.text,
+	})
+	expect(asLinkAttrs(field, { linkResolver: () => "/linkResolver" })).toEqual({
+		href: "/linkResolver",
+		target: undefined,
+		rel: undefined,
+		text: field.text,
 	})
 })
 
@@ -116,11 +194,13 @@ it("resolves a document", (ctx) => {
 		href: doc.url,
 		target: undefined,
 		rel: undefined,
+		text: undefined,
 	})
 	expect(asLinkAttrs(doc, { linkResolver: () => "/linkResolver" })).toEqual({
 		href: "/linkResolver",
 		target: undefined,
 		rel: undefined,
+		text: undefined,
 	})
 })
 


### PR DESCRIPTION
**Resolves**: [DT-2284](https://linear.app/prismic/issue/DT-2284/aadev-prismic-client-supports-text-in-link-fields-helper-functions)

### Description

It adds support for display text in links when using the `asLinkAttrs` helper function. Tests updated to match.

_Note: I had to use an override to get it to work. This should be removed in the actual release process._ 

### Checklist

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.