### PR TITLE
support link text with boolean config & empty link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [7.9.0-alpha.3](https://github.com/prismicio/prismic-client/compare/v7.8.1...v7.9.0-alpha.3) (2024-09-10)
+
+
+### Chore
+
+* **deps:** maintain lock file ([601edd5](https://github.com/prismicio/prismic-client/commit/601edd55ed2594010da740f3f40250a7f517cf5c))
+
+## [7.9.0-alpha.2](https://github.com/prismicio/prismic-client/compare/v7.9.0-alpha.1...v7.9.0-alpha.2) (2024-08-27)
+
+
+### Chore
+
+* **release:** 7.9.0-alpha.2 ([000f146](https://github.com/prismicio/prismic-client/commit/000f146d25b84b2937c3accaffa54ab936a78de8))
+* revert previous changes ([c53de86](https://github.com/prismicio/prismic-client/commit/c53de86a7ed749f0f9d8999b9e58564d9a8efe35))
+
+## [7.9.0-alpha.1](https://github.com/prismicio/prismic-client/compare/v7.9.0-alpha.0...v7.9.0-alpha.1) (2024-08-27)
+
+
+### Features
+
+* use KeyTextField for link text value definition ([1a4c51a](https://github.com/prismicio/prismic-client/commit/1a4c51a389ed4d06cf69c3edcb215559ba91fe99))
+
+
+### Chore
+
+* **release:** 7.9.0-alpha.1 ([d940fcd](https://github.com/prismicio/prismic-client/commit/d940fcdb023de34765006607f7f34481de00a6ef))
+* remove changelog for alpha ([50fc797](https://github.com/prismicio/prismic-client/commit/50fc797372726c0abc575b9f1b0a56d5db939bb1))
+
+## [7.9.0-alpha.0](https://github.com/prismicio/prismic-client/compare/v7.8.0...v7.9.0-alpha.0) (2024-08-14)
+
+
+### Features
+
+* add text property to link models ([40d0e0b](https://github.com/prismicio/prismic-client/commit/40d0e0be3ce8038cd36e8cdf3350ffa9893ada98))
+* add text to link value models ([8459d75](https://github.com/prismicio/prismic-client/commit/8459d75608c1af8319adafd2b3bf73555569a434))
+
+
+### Chore
+
+* **release:** 7.9.0-alpha.0 ([f2021c0](https://github.com/prismicio/prismic-client/commit/f2021c053b9aac1c17b7bbd1845c91eab7b0d176))
+* update package version ([c06b383](https://github.com/prismicio/prismic-client/commit/c06b383ff41f01e253641c7852a4e9701725bdba))
+
 ## [7.9.0-alpha.1](https://github.com/prismicio/prismic-client/compare/v7.9.0-alpha.0...v7.9.0-alpha.1) (2024-08-27)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@prismicio/client",
-	"version": "7.9.0-alpha.2",
+	"version": "7.9.0-alpha.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@prismicio/client",
-			"version": "7.9.0-alpha.2",
+			"version": "7.9.0-alpha.3",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"imgix-url-builder": "^0.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@prismicio/client",
-	"version": "7.9.0-alpha.2",
+	"version": "7.9.0-alpha.3",
 	"description": "The official JavaScript + TypeScript client library for Prismic",
 	"keywords": [
 		"typescript",

--- a/src/types/model/contentRelationship.ts
+++ b/src/types/model/contentRelationship.ts
@@ -1,6 +1,5 @@
 import type { CustomTypeModelFieldType } from "./types"
 
-import type { CustomTypeModelKeyTextField } from "./keyText"
 import type { CustomTypeModelLinkSelectType } from "./link"
 
 /**
@@ -19,6 +18,5 @@ export interface CustomTypeModelContentRelationshipField<
 		select: typeof CustomTypeModelLinkSelectType.Document
 		customtypes?: readonly CustomTypeIDs[]
 		tags?: readonly Tags[]
-		text?: CustomTypeModelKeyTextField
 	}
 }

--- a/src/types/model/link.ts
+++ b/src/types/model/link.ts
@@ -1,7 +1,5 @@
 import type { CustomTypeModelFieldType } from "./types"
 
-import type { CustomTypeModelKeyTextField } from "./keyText"
-
 /**
  * A link custom type field.
  *
@@ -15,7 +13,7 @@ export interface CustomTypeModelLinkField {
 		select?:
 			| null
 			| (typeof CustomTypeModelLinkSelectType)[keyof typeof CustomTypeModelLinkSelectType]
-		text?: CustomTypeModelKeyTextField
+		allowText?: boolean
 		allowTargetBlank?: boolean
 	}
 }

--- a/src/types/model/linkToMedia.ts
+++ b/src/types/model/linkToMedia.ts
@@ -1,6 +1,5 @@
 import type { CustomTypeModelFieldType } from "./types"
 
-import type { CustomTypeModelKeyTextField } from "./keyText"
 import type { CustomTypeModelLinkSelectType } from "./link"
 
 /**
@@ -14,6 +13,6 @@ export interface CustomTypeModelLinkToMediaField {
 		label?: string | null
 		placeholder?: string
 		select: typeof CustomTypeModelLinkSelectType.Media
-		text?: CustomTypeModelKeyTextField
+		allowText?: boolean
 	}
 }

--- a/src/types/value/link.ts
+++ b/src/types/value/link.ts
@@ -24,6 +24,7 @@ export type EmptyLinkField<
 	Type extends (typeof LinkType)[keyof typeof LinkType] = typeof LinkType.Any,
 > = {
 	link_type: Type | string
+	text?: string
 }
 
 /**

--- a/test/types/customType-contentRelationship.types.ts
+++ b/test/types/customType-contentRelationship.types.ts
@@ -104,9 +104,6 @@ expectType<prismic.CustomTypeModelContentRelationshipField>({
 	config: {
 		label: "string",
 		select: prismic.CustomTypeModelLinkSelectType.Document,
-		text: {
-			type: prismic.CustomTypeModelFieldType.Text,
-		},
 	},
 })
 

--- a/test/types/customType-link.types.ts
+++ b/test/types/customType-link.types.ts
@@ -67,9 +67,7 @@ expectType<prismic.CustomTypeModelLinkField>({
 	type: prismic.CustomTypeModelFieldType.Link,
 	config: {
 		label: "string",
-		text: {
-			type: prismic.CustomTypeModelFieldType.Text,
-		},
+		allowText: true,
 	},
 })
 

--- a/test/types/customType-linkToMedia.types.ts
+++ b/test/types/customType-linkToMedia.types.ts
@@ -48,9 +48,7 @@ expectType<prismic.CustomTypeModelLinkToMediaField>({
 	config: {
 		label: "string",
 		select: prismic.CustomTypeModelLinkSelectType.Media,
-		text: {
-			type: prismic.CustomTypeModelFieldType.Text,
-		},
+		allowText: true,
 	},
 })
 

--- a/test/types/fields-contentRelationship.types.ts
+++ b/test/types/fields-contentRelationship.types.ts
@@ -79,6 +79,25 @@ expectType<prismic.ContentRelationshipField<string, string, never, "filled">>(
 )
 
 /**
+ * Empty state with text.
+ */
+expectType<prismic.ContentRelationshipField>({
+	link_type: prismic.LinkType.Document,
+	text: "string",
+})
+expectType<prismic.ContentRelationshipField<string, string, never, "empty">>({
+	link_type: prismic.LinkType.Document,
+	text: "string",
+})
+expectType<prismic.ContentRelationshipField<string, string, never, "filled">>(
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	{
+		link_type: prismic.LinkType.Document,
+		text: "string",
+	},
+)
+
+/**
  * Supports custom document type.
  */
 expectType<prismic.ContentRelationshipField<"foo">>({

--- a/test/types/fields-link.types.ts
+++ b/test/types/fields-link.types.ts
@@ -88,12 +88,82 @@ expectType<prismic.LinkField<string, string, never, "empty">>({
 expectType<prismic.LinkField>({
 	link_type: prismic.LinkType.Any,
 })
+expectType<prismic.LinkField<string, string, never, "filled">>({
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	link_type: prismic.LinkType.Any,
+})
+expectType<prismic.LinkField>({
+	link_type: prismic.LinkType.Web,
+})
+expectType<prismic.LinkField<string, string, never, "filled">>(
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	{
+		link_type: prismic.LinkType.Web,
+	},
+)
+expectType<prismic.LinkField>({
+	link_type: prismic.LinkType.Document,
+})
+expectType<prismic.LinkField<string, string, never, "filled">>(
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	{
+		link_type: prismic.LinkType.Document,
+	},
+)
+expectType<prismic.LinkField>({
+	link_type: prismic.LinkType.Media,
+})
+expectType<prismic.LinkField<string, string, never, "filled">>(
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	{
+		link_type: prismic.LinkType.Media,
+	},
+)
+
+/**
+ * Empty state with text.
+ */
+expectType<prismic.LinkField<string, string, never, "empty">>({
+	link_type: prismic.LinkType.Web,
+	text: "string",
+})
+expectType<prismic.LinkField<string, string, never, "filled">>(
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	{
+		link_type: prismic.LinkType.Web,
+		text: "string",
+	},
+)
+expectType<prismic.LinkField<string, string, never, "empty">>({
+	link_type: prismic.LinkType.Document,
+	text: "string",
+})
+expectType<prismic.LinkField<string, string, never, "filled">>(
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	{
+		link_type: prismic.LinkType.Document,
+		text: "string",
+	},
+)
+expectType<prismic.LinkField<string, string, never, "empty">>({
+	link_type: prismic.LinkType.Media,
+	text: "string",
+})
+expectType<prismic.LinkField<string, string, never, "filled">>(
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	{
+		link_type: prismic.LinkType.Media,
+		text: "string",
+	},
+)
 expectType<prismic.LinkField<string, string, never, "empty">>({
 	link_type: prismic.LinkType.Any,
+	text: "string",
 })
 expectType<prismic.LinkField<string, string, never, "filled">>({
 	// @ts-expect-error - Filled fields cannot contain an empty value.
 	link_type: prismic.LinkType.Any,
+	text: "string",
 })
 
 /**

--- a/test/types/fields-linkToMedia.types.ts
+++ b/test/types/fields-linkToMedia.types.ts
@@ -71,3 +71,22 @@ expectType<prismic.LinkToMediaField<"filled">>(
 		link_type: prismic.LinkType.Media,
 	},
 )
+
+/**
+ * Empty state with text.
+ */
+expectType<prismic.LinkToMediaField>({
+	link_type: prismic.LinkType.Media,
+	text: "string",
+})
+expectType<prismic.LinkToMediaField<"empty">>({
+	link_type: prismic.LinkType.Media,
+	text: "string",
+})
+expectType<prismic.LinkToMediaField<"filled">>(
+	// @ts-expect-error - Filled fields cannot contain an empty value.
+	{
+		link_type: prismic.LinkType.Media,
+		text: "string",
+	},
+)


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2283](https://linear.app/prismic/issue/DT-2283/aadev-prismic-client-supports-text-in-link-fields)

### Description

- Support empty link with text
- Update link config to allow text with a boolean and not a key text config

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.