### PR TITLE
feat: add `createWriteClient` and `createMigration`

### DIFF
--- a/src/createMigration.ts
+++ b/src/createMigration.ts
@@ -95,10 +95,15 @@ export class Migration<TDocument extends PrismicDocument> {
 		)
 	}
 
-	getSingle(
-		type: TDocument["type"],
-	): PrismicMigrationDocument<TDocument> | undefined {
-		return this.documents.find((doc) => doc.document.type === type)
+	getSingle<TType extends TDocument["type"]>(
+		type: TType,
+	): PrismicMigrationDocument<Extract<TDocument, { type: TType }>> | undefined {
+		return this.documents.find(
+			(
+				doc,
+			): doc is PrismicMigrationDocument<Extract<TDocument, { type: TType }>> =>
+				doc.document.type === type,
+		)
 	}
 }
 

--- a/src/createMigration.ts
+++ b/src/createMigration.ts
@@ -3,7 +3,7 @@ import type {
 	FilledContentRelationshipField,
 } from "./types/value/contentRelationship"
 import type { PrismicDocument } from "./types/value/document"
-import type { LinkField } from "./types/value/link"
+import type { EmptyLinkField, LinkField } from "./types/value/link"
 
 type PendingPrismicDocument<TDocument extends PrismicDocument> =
 	InjectMigrationSpecificTypes<
@@ -11,7 +11,7 @@ type PendingPrismicDocument<TDocument extends PrismicDocument> =
 	>
 
 type ExistingPrismicDocument<TDocument extends PrismicDocument> =
-	PendingPrismicDocument<TDocument> & Pick<TDocument, "id">
+	InjectMigrationSpecificTypes<TDocument>
 
 type MigrationDocument<TDocument extends PrismicDocument> =
 	| PendingPrismicDocument<TDocument>
@@ -24,21 +24,20 @@ type MigrationContentRelationship =
 	| (() => PrismicDocument | PrismicMigrationDocument | undefined)
 	| (() => Promise<PrismicDocument | PrismicMigrationDocument | undefined>)
 
-type MigrationFilledContentRelationshipField = Pick<
-	FilledContentRelationshipField,
-	"link_type" | "id"
->
+type MigrationContentRelationshipField =
+	| Pick<FilledContentRelationshipField, "link_type" | "id">
+	| EmptyLinkField<"Document">
 
-type InjectMigrationSpecificTypes<T> = T extends null
-	? undefined
-	: T extends LinkField | ContentRelationshipField
-		? T | MigrationContentRelationship
-		: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-			T extends Record<any, any>
-			? { [P in keyof T]: InjectMigrationSpecificTypes<T[P]> }
-			: T extends Array<infer U>
-				? Array<InjectMigrationSpecificTypes<U>>
-				: T
+type InjectMigrationSpecificTypes<T> = T extends
+	| LinkField
+	| ContentRelationshipField
+	? T | MigrationContentRelationship
+	: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+		T extends Record<any, any>
+		? { [P in keyof T]: InjectMigrationSpecificTypes<T[P]> }
+		: T extends Array<infer U>
+			? Array<InjectMigrationSpecificTypes<U>>
+			: T
 
 export const createMigration = <
 	TDocument extends PrismicDocument,
@@ -83,6 +82,27 @@ export class Migration<TDocument extends PrismicDocument> {
 		return migrationDocument
 	}
 
+	createDocumentFromPrismic(
+		document: TDocument,
+		title: string,
+	): PrismicMigrationDocument<TDocument> {
+		const migrationDocument = new PrismicMigrationDocument(
+			this.#migratePrismicDocumentData({
+				type: document.type,
+				lang: document.lang,
+				uid: document.uid,
+				tags: document.tags,
+				data: document.data,
+			} as PendingPrismicDocument<TDocument>),
+			title,
+			{ originalPrismicID: document.id },
+		)
+
+		this.documents.push(migrationDocument)
+
+		return migrationDocument
+	}
+
 	getByUID<TType extends TDocument["type"]>(
 		type: TType,
 		uid: string,
@@ -105,6 +125,45 @@ export class Migration<TDocument extends PrismicDocument> {
 				doc.document.type === type,
 		)
 	}
+
+	getByOriginalID(id: string): PrismicMigrationDocument | undefined {
+		return this.documents.find((doc) => doc.originalPrismicID === id)
+	}
+
+	#migratePrismicDocumentData(
+		input: PendingPrismicDocument<TDocument>,
+	): PendingPrismicDocument<TDocument>
+	#migratePrismicDocumentData(input: unknown): unknown {
+		if (isFilledContentRelationshipField(input)) {
+			if (input.isBroken) {
+				return { link_type: "Document", id: "_____broken_____", isBroken: true }
+			}
+
+			return () => this.getByOriginalID(input.id)
+		}
+
+		if (input === null) {
+			return undefined
+		}
+
+		if (Array.isArray(input)) {
+			return input.map((element) => this.#migratePrismicDocumentData(element))
+		}
+
+		if (typeof input === "object") {
+			const res: Record<PropertyKey, unknown> = {}
+
+			for (const key in input) {
+				res[key] = this.#migratePrismicDocumentData(
+					input[key as keyof typeof input],
+				)
+			}
+
+			return res
+		}
+
+		return input
+	}
 }
 
 export class PrismicMigrationDocument<
@@ -114,22 +173,31 @@ export class PrismicMigrationDocument<
 	title?: string
 	masterLanguageDocument?: MigrationContentRelationship
 
+	// Only used when the document originally came from Prismic.
+	originalPrismicID?: string
+
 	constructor(
 		document: MigrationDocument<TDocument>,
 		title?: string,
 		options?: {
 			masterLanguageDocument?: MigrationContentRelationship
+			originalPrismicID?: string
 		},
 	) {
 		this.document = document
 		this.title = title
 		this.masterLanguageDocument = options?.masterLanguageDocument
+		this.originalPrismicID = options?.originalPrismicID
 	}
 }
 
 export async function resolveMigrationDocumentData(
 	input: unknown,
 ): Promise<unknown> {
+	if (input === null) {
+		return undefined
+	}
+
 	if (input instanceof PrismicMigrationDocument || isPrismicDocument(input)) {
 		return resolveMigrationContentRelationship(input)
 	}
@@ -161,7 +229,7 @@ export async function resolveMigrationDocumentData(
 
 export async function resolveMigrationContentRelationship(
 	relation: MigrationContentRelationship,
-): Promise<MigrationFilledContentRelationshipField | undefined> {
+): Promise<MigrationContentRelationshipField> {
 	if (typeof relation === "function") {
 		return resolveMigrationContentRelationship(await relation())
 	}
@@ -169,12 +237,14 @@ export async function resolveMigrationContentRelationship(
 	if (relation instanceof PrismicMigrationDocument) {
 		return relation.document.id
 			? { link_type: "Document", id: relation.document.id }
-			: undefined
+			: { link_type: "Document" }
 	}
 
 	if (relation) {
 		return { link_type: "Document", id: relation.id }
 	}
+
+	return { link_type: "Document" }
 }
 
 function isPrismicDocument(input: unknown): input is PrismicDocument {
@@ -190,4 +260,15 @@ function isPrismicDocument(input: unknown): input is PrismicDocument {
 	} catch {
 		return false
 	}
+}
+
+function isFilledContentRelationshipField(
+	input: unknown,
+): input is FilledContentRelationshipField {
+	return (
+		typeof input === "object" &&
+		input !== null &&
+		"link_type" in input &&
+		input.link_type === "Document"
+	)
 }

--- a/src/createMigration.ts
+++ b/src/createMigration.ts
@@ -1,0 +1,188 @@
+import type {
+	ContentRelationshipField,
+	FilledContentRelationshipField,
+} from "./types/value/contentRelationship"
+import type { PrismicDocument } from "./types/value/document"
+import type { LinkField } from "./types/value/link"
+
+type PendingPrismicDocument<TDocument extends PrismicDocument> =
+	InjectMigrationSpecificTypes<
+		Pick<TDocument, "type" | "uid" | "lang" | "tags" | "data">
+	>
+
+type ExistingPrismicDocument<TDocument extends PrismicDocument> =
+	PendingPrismicDocument<TDocument> & Pick<TDocument, "id">
+
+type MigrationDocument<TDocument extends PrismicDocument> =
+	| PendingPrismicDocument<TDocument>
+	| ExistingPrismicDocument<TDocument>
+
+type MigrationContentRelationship =
+	| PrismicDocument
+	| PrismicMigrationDocument
+	| undefined
+	| (() => PrismicDocument | PrismicMigrationDocument | undefined)
+	| (() => Promise<PrismicDocument | PrismicMigrationDocument | undefined>)
+
+type MigrationFilledContentRelationshipField = Pick<
+	FilledContentRelationshipField,
+	"link_type" | "id"
+>
+
+type InjectMigrationSpecificTypes<T> = T extends null
+	? undefined
+	: T extends LinkField | ContentRelationshipField
+		? T | MigrationContentRelationship
+		: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+			T extends Record<any, any>
+			? { [P in keyof T]: InjectMigrationSpecificTypes<T[P]> }
+			: T extends Array<infer U>
+				? Array<InjectMigrationSpecificTypes<U>>
+				: T
+
+export const createMigration = <
+	TDocument extends PrismicDocument,
+>(): Migration<TDocument> => new Migration<TDocument>()
+
+export class Migration<TDocument extends PrismicDocument> {
+	documents: PrismicMigrationDocument<TDocument>[] = []
+
+	createDocument(
+		document: PendingPrismicDocument<TDocument>,
+		title: string,
+		options?: {
+			masterLanguageDocument?: MigrationContentRelationship
+		},
+	): PrismicMigrationDocument<TDocument> {
+		const migrationDocument = new PrismicMigrationDocument(
+			document,
+			title,
+			options,
+		)
+
+		this.documents.push(migrationDocument)
+
+		return migrationDocument
+	}
+
+	updateDocument(
+		document: ExistingPrismicDocument<TDocument>,
+		title?: string,
+		options?: {
+			masterLanguageDocument?: MigrationContentRelationship
+		},
+	): PrismicMigrationDocument<TDocument> {
+		const migrationDocument = new PrismicMigrationDocument(
+			document,
+			title,
+			options,
+		)
+
+		this.documents.push(migrationDocument)
+
+		return migrationDocument
+	}
+
+	getByUID<TType extends TDocument["type"]>(
+		type: TType,
+		uid: string,
+	): PrismicMigrationDocument<Extract<TDocument, { type: TType }>> | undefined {
+		return this.documents.find(
+			(
+				doc,
+			): doc is PrismicMigrationDocument<Extract<TDocument, { type: TType }>> =>
+				doc.document.type === type && doc.document.uid === uid,
+		)
+	}
+
+	getSingle(
+		type: TDocument["type"],
+	): PrismicMigrationDocument<TDocument> | undefined {
+		return this.documents.find((doc) => doc.document.type === type)
+	}
+}
+
+export class PrismicMigrationDocument<
+	TDocument extends PrismicDocument = PrismicDocument,
+> {
+	document: MigrationDocument<TDocument> & Partial<Pick<TDocument, "id">>
+	title?: string
+	masterLanguageDocument?: MigrationContentRelationship
+
+	constructor(
+		document: MigrationDocument<TDocument>,
+		title?: string,
+		options?: {
+			masterLanguageDocument?: MigrationContentRelationship
+		},
+	) {
+		this.document = document
+		this.title = title
+		this.masterLanguageDocument = options?.masterLanguageDocument
+	}
+}
+
+export async function resolveMigrationDocumentData(
+	input: unknown,
+): Promise<unknown> {
+	if (input instanceof PrismicMigrationDocument || isPrismicDocument(input)) {
+		return resolveMigrationContentRelationship(input)
+	}
+
+	if (typeof input === "function") {
+		return await resolveMigrationDocumentData(await input())
+	}
+
+	if (Array.isArray(input)) {
+		return await Promise.all(
+			input.map(async (element) => await resolveMigrationDocumentData(element)),
+		)
+	}
+
+	if (typeof input === "object") {
+		const res: Record<PropertyKey, unknown> = {}
+
+		for (const key in input) {
+			res[key] = await resolveMigrationDocumentData(
+				input[key as keyof typeof input],
+			)
+		}
+
+		return res
+	}
+
+	return input
+}
+
+export async function resolveMigrationContentRelationship(
+	relation: MigrationContentRelationship,
+): Promise<MigrationFilledContentRelationshipField | undefined> {
+	if (typeof relation === "function") {
+		return resolveMigrationContentRelationship(await relation())
+	}
+
+	if (relation instanceof PrismicMigrationDocument) {
+		return relation.document.id
+			? { link_type: "Document", id: relation.document.id }
+			: undefined
+	}
+
+	if (relation) {
+		return { link_type: "Document", id: relation.id }
+	}
+}
+
+function isPrismicDocument(input: unknown): input is PrismicDocument {
+	try {
+		return (
+			typeof input === "object" &&
+			input !== null &&
+			"id" in input &&
+			"href" in input &&
+			typeof input.href === "string" &&
+			new URL(input.href).host.endsWith(".prismic.io")
+		)
+	} catch {
+		return false
+	}
+}

--- a/src/createWriteClient.ts
+++ b/src/createWriteClient.ts
@@ -1,0 +1,108 @@
+import type { PrismicDocument } from "./types/value/document"
+
+import { Client, type ClientConfig } from "./createClient"
+import {
+	type Migration,
+	type PrismicMigrationDocument,
+	resolveMigrationContentRelationship,
+	resolveMigrationDocumentData,
+} from "./createMigration"
+import { getRepositoryName } from "./getRepositoryName"
+
+export const createWriteClient = <TDocuments extends PrismicDocument>(
+	repositoryName: string,
+	config: ClientConfig & { writeToken: string },
+): WriteClient<TDocuments> =>
+	new WriteClient<TDocuments>(repositoryName, config)
+
+export class WriteClient<
+	TDocument extends PrismicDocument = PrismicDocument,
+> extends Client<TDocument> {
+	writeToken: string
+	migrationAPIEndpoint = "https://migration.prismic.io"
+
+	constructor(
+		repositoryName: string,
+		config: ClientConfig & { writeToken: string },
+	) {
+		super(repositoryName)
+		this.writeToken = config.writeToken
+	}
+
+	async migrate(migration: Migration<TDocument>): Promise<void> {
+		const docsWithoutMasterLangDoc = migration.documents.filter(
+			(doc) => !doc.masterLanguageDocument,
+		)
+		const docsWithMasterLangDoc = migration.documents.filter(
+			(doc) => doc.masterLanguageDocument,
+		)
+
+		// 1. Upload all docs without a master lang with no data
+		for (const doc of docsWithoutMasterLangDoc) {
+			await this.#pushDocument(doc, { withData: false })
+		}
+
+		// 2. Upload all documents with a master lang with no data
+		for (const doc of docsWithMasterLangDoc) {
+			await this.#pushDocument(doc, { withData: false })
+		}
+
+		// 3. Upload all documents with resolved data
+		for (const doc of migration.documents) {
+			await this.#pushDocument(doc)
+		}
+	}
+
+	async #pushDocument(
+		doc: PrismicMigrationDocument<TDocument>,
+		options?: { withData?: boolean },
+	) {
+		const isUpdating = Boolean(doc.document.id)
+
+		const documentData =
+			(options?.withData ?? true)
+				? await resolveMigrationDocumentData(doc.document.data)
+				: {}
+		const alternateLanguageDocument = await resolveMigrationContentRelationship(
+			doc.masterLanguageDocument,
+		)
+
+		const body = {
+			...doc.document,
+			data: documentData,
+			title: doc.title,
+			alternate_language_id: alternateLanguageDocument?.id,
+		}
+
+		const response = await this.#fetch(
+			new URL(
+				isUpdating ? `documents/${doc.document.id}` : "documents",
+				this.migrationAPIEndpoint,
+			),
+			{ method: isUpdating ? "PUT" : "POST", body: JSON.stringify(body) },
+		)
+		if (!response.ok) {
+			throw new Error(`Failed to push document: ${await response.text()}`)
+		}
+
+		const responseBody = await response.json()
+		doc.document.id = responseBody.id
+
+		// Wait for API rate limiting
+		await new Promise((res) => setTimeout(res, 1500))
+
+		return responseBody
+	}
+
+	async #fetch(input: RequestInfo | URL, init?: RequestInit) {
+		const request = new Request(input, init)
+
+		const headers = new Headers(init?.headers)
+		headers.set("repository", getRepositoryName(this.endpoint))
+		headers.set("authorization", `Bearer ${this.writeToken}`)
+		headers.set("x-api-key", "g2DA3EKWvx8uxVYcNFrmT5nJpon1Vi9V4XcOibJD")
+		headers.set("content-type", "application/json")
+
+		return fetch(new Request(request, { headers }))
+	}
+}

--- a/src/createWriteClient.ts
+++ b/src/createWriteClient.ts
@@ -71,7 +71,10 @@ export class WriteClient<
 			...doc.document,
 			data: documentData,
 			title: doc.title,
-			alternate_language_id: alternateLanguageDocument?.id,
+			alternate_language_id:
+				"id" in alternateLanguageDocument
+					? alternateLanguageDocument.id
+					: undefined,
 		}
 
 		const response = await this.#fetch(

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,13 @@ export type {
 } from "./buildQueryURL"
 
 //=============================================================================
+// WriteClient - Write content to Prismic.
+//=============================================================================
+
+export { createMigration, Migration } from "./createMigration"
+export { createWriteClient, WriteClient } from "./createWriteClient"
+
+//=============================================================================
 // Helpers - Manipulate content from Prismic.
 //=============================================================================
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: N/A

### Description

A proof-of-concept alternative to #350. Do not merge.

This PR does not handle assets. A strategy similar to the one presented here for documents should be possible for assets.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

```typescript
import {
  createWriteClient,
  createMigration,
  type Content,
} from "@prismicio/client";

const client = createWriteClient<Content.AllDocumentTypes>(
  "example-prismic-repo",
  { writeToken: "..." },
);
const migration = createMigration<Content.AllDocumentTypes>();

// Creating a document with a content relationship.
// This example also demonstrates a circular reference.
migration.createDocument(
  {
    type: "page",
    lang: "en-us",
    uid: "page-1",
    tags: [],
    data: {
      title: [
        {
          type: "heading1",
          text: "Hello from `@prismicio/client`",
          spans: [],
        },
      ],
      related_page: () => migration.getByUID("page", "page-2"),
    },
  },
  "Page 1",
);
migration.createDocument(
  {
    type: "page",
    lang: "en-us",
    uid: "page-2",
    tags: [],
    data: {
      title: [
        {
          type: "heading1",
          text: "This is another page",
          spans: [],
        },
      ],
      related_page: () => migration.getByUID("page", "page-1"),
    },
  },
  "Page 2",
);

// Updating an existing document.
// This example also shows a hyperlink in a rich text field.
const anotherPage = await client.getByUID("page", "another-page");
anotherPage.description = [
  {
    type: "paragraph",
    text: "Not to be confused with another page.",
    spans: [
      {
        type: "hyperlink",
        start: 0,
        end: 10,
        data: () => client.getByUID("page", "home"),
      },
    ],
  },
];
migration.updateDocument(anotherPage);

// Copying a document from Prismic.
// It handles updating old relationship IDs to new ones.
// This isn't a good example since the document is from the original repo,
// but the same logic is applied.
const home = await client.getByUID("page", "home");
home.uid = "copied-home";
migration.createDocumentFromPrismic(home, "Home");

await client.migrate(migration);
```

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
    Please use these labels when submitting a review:
    :question: #ask:&ensp;Ask a question.
    :bulb: #idea:&ensp;Suggest an idea.
    :warning: #issue:&ensp;Strongly suggest a change.
    :tada: #nice:&ensp;Share a compliment.
