### PR TITLE
feat: retry invalid/expired refs

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1721,6 +1721,14 @@ export class Client<
 				throw error
 			}
 
+			// If no explicit ref is given (i.e. the master ref from
+			// /api/v2 is used), clear the cached repository value.
+			// Clearing the cached value prevents other methods from
+			// using a known-stale ref.
+			if (!params?.ref) {
+				this.cachedRepository = undefined
+			}
+
 			const masterRef = error.message.match(/Master ref is: (?<ref>.*)$/)
 				?.groups?.ref
 			if (!masterRef) {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -74,9 +74,9 @@ export const GET_ALL_QUERY_DELAY = 500
 const DEFUALT_RETRY_AFTER_MS = 1000
 
 /**
- * The maximum number of attemps to retry a query with an invalid ref before
- * halting. We allow multiple attemps as each attemp may return a different ref.
- * Capping the number of attemps prevents infinite loops.
+ * The maximum number of attemps to retry a query with an invalid ref. We allow
+ * multiple attempts since each attempt may use a different (and possibly
+ * invalid) ref. Capping the number of attemps prevents infinite loops.
  */
 const MAX_INVALID_REF_RETRY_ATTEMPS = 3
 

--- a/test/__testutils__/testInvalidRefRetry.ts
+++ b/test/__testutils__/testInvalidRefRetry.ts
@@ -15,126 +15,156 @@ type TestInvalidRefRetryArgs = {
 }
 
 export const testInvalidRefRetry = (args: TestInvalidRefRetryArgs): void => {
-	it.concurrent(
-		"retries with the master ref when an invalid ref is used",
-		async (ctx) => {
-			const client = createTestClient({ ctx })
-			const badRef = ctx.mock.api.ref().ref
-			const masterRef = ctx.mock.api.ref().ref
-			const queryResponse = ctx.mock.api.query({
-				documents: [ctx.mock.value.document()],
-			})
+	it("retries with the master ref when an invalid ref is used", async (ctx) => {
+		const client = createTestClient({ ctx })
+		const badRef = ctx.mock.api.ref().ref
+		const masterRef = ctx.mock.api.ref().ref
+		const queryResponse = ctx.mock.api.query({
+			documents: [ctx.mock.value.document()],
+		})
 
-			const triedRefs: (string | null)[] = []
+		const triedRefs = new Set<string | null>()
 
-			mockPrismicRestAPIV2({ ctx, queryResponse })
-			const endpoint = new URL(
-				"documents/search",
-				`${client.documentAPIEndpoint}/`,
-			).toString()
-			ctx.server.use(
-				rest.get(endpoint, (req) => {
-					triedRefs.push(req.url.searchParams.get("ref"))
-				}),
-				rest.get(endpoint, (_req, res, ctx) =>
-					res.once(
-						ctx.json({
-							type: "api_notfound_error",
-							message: `Master ref is: ${masterRef}`,
-						}),
-						ctx.status(404),
-					),
+		mockPrismicRestAPIV2({ ctx, queryResponse })
+		const endpoint = new URL(
+			"documents/search",
+			`${client.documentAPIEndpoint}/`,
+		).toString()
+		ctx.server.use(
+			rest.get(endpoint, (req) => {
+				triedRefs.add(req.url.searchParams.get("ref"))
+			}),
+			rest.get(endpoint, (_req, res, ctx) =>
+				res.once(
+					ctx.json({
+						type: "api_notfound_error",
+						message: `Master ref is: ${masterRef}`,
+					}),
+					ctx.status(404),
 				),
-			)
+			),
+		)
 
-			const consoleWarnSpy = vi
-				.spyOn(console, "warn")
-				.mockImplementation(() => void 0)
-			await args.run(client, { ref: badRef })
-			consoleWarnSpy.mockRestore()
+		const consoleWarnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => void 0)
+		await args.run(client, { ref: badRef })
+		consoleWarnSpy.mockRestore()
 
-			expect(triedRefs).toStrictEqual([badRef, masterRef])
-		},
-	)
+		expect([...triedRefs]).toStrictEqual([badRef, masterRef])
+	})
 
-	it.concurrent(
-		"retries with the master ref when an expired ref is used",
-		async (ctx) => {
-			const client = createTestClient({ ctx })
-			const badRef = ctx.mock.api.ref().ref
-			const masterRef = ctx.mock.api.ref().ref
-			const queryResponse = ctx.mock.api.query({
-				documents: [ctx.mock.value.document()],
-			})
+	it("retries with the master ref when an expired ref is used", async (ctx) => {
+		const client = createTestClient({ ctx })
+		const badRef = ctx.mock.api.ref().ref
+		const masterRef = ctx.mock.api.ref().ref
+		const queryResponse = ctx.mock.api.query({
+			documents: [ctx.mock.value.document()],
+		})
 
-			const triedRefs: (string | null)[] = []
+		const triedRefs = new Set<string | null>()
 
-			mockPrismicRestAPIV2({ ctx, queryResponse })
-			const endpoint = new URL(
-				"documents/search",
-				`${client.documentAPIEndpoint}/`,
-			).toString()
-			ctx.server.use(
-				rest.get(endpoint, (req) => {
-					triedRefs.push(req.url.searchParams.get("ref"))
-				}),
-				rest.get(endpoint, (_req, res, ctx) =>
-					res.once(
-						ctx.json({ message: `Master ref is: ${masterRef}` }),
-						ctx.status(410),
-					),
+		mockPrismicRestAPIV2({ ctx, queryResponse })
+		const endpoint = new URL(
+			"documents/search",
+			`${client.documentAPIEndpoint}/`,
+		).toString()
+		ctx.server.use(
+			rest.get(endpoint, (req) => {
+				triedRefs.add(req.url.searchParams.get("ref"))
+			}),
+			rest.get(endpoint, (_req, res, ctx) =>
+				res.once(
+					ctx.json({ message: `Master ref is: ${masterRef}` }),
+					ctx.status(410),
 				),
-			)
+			),
+		)
 
-			const consoleWarnSpy = vi
-				.spyOn(console, "warn")
-				.mockImplementation(() => void 0)
-			await args.run(client, { ref: badRef })
-			consoleWarnSpy.mockRestore()
+		const consoleWarnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => void 0)
+		await args.run(client, { ref: badRef })
+		consoleWarnSpy.mockRestore()
 
-			expect(triedRefs).toStrictEqual([badRef, masterRef])
-		},
-	)
+		expect([...triedRefs]).toStrictEqual([badRef, masterRef])
+	})
 
-	it.concurrent(
-		"throws if the maximum number of retries when an invalid ref is used is reached",
-		async (ctx) => {
-			const client = createTestClient({ ctx })
-			const queryResponse = ctx.mock.api.query({
-				documents: [ctx.mock.value.document()],
-			})
+	it("throws if the maximum number of retries when an invalid ref is used is reached", async (ctx) => {
+		const client = createTestClient({ ctx })
+		const queryResponse = ctx.mock.api.query({
+			documents: [ctx.mock.value.document()],
+		})
 
-			const triedRefs: (string | null)[] = []
+		const triedRefs = new Set<string | null>()
 
-			mockPrismicRestAPIV2({ ctx, queryResponse })
-			const endpoint = new URL(
-				"documents/search",
-				`${client.documentAPIEndpoint}/`,
-			).toString()
-			ctx.server.use(
-				rest.get(endpoint, (req) => {
-					triedRefs.push(req.url.searchParams.get("ref"))
-				}),
-				rest.get(endpoint, (_req, res, requestCtx) =>
-					res(
-						requestCtx.json({
-							type: "api_notfound_error",
-							message: `Master ref is: ${ctx.mock.api.ref().ref}`,
-						}),
-						requestCtx.status(404),
-					),
+		mockPrismicRestAPIV2({ ctx, queryResponse })
+		const endpoint = new URL(
+			"documents/search",
+			`${client.documentAPIEndpoint}/`,
+		).toString()
+		ctx.server.use(
+			rest.get(endpoint, (req) => {
+				triedRefs.add(req.url.searchParams.get("ref"))
+			}),
+			rest.get(endpoint, (_req, res, requestCtx) =>
+				res(
+					requestCtx.json({
+						type: "api_notfound_error",
+						message: `Master ref is: ${ctx.mock.api.ref().ref}`,
+					}),
+					requestCtx.status(404),
 				),
-			)
+			),
+		)
 
-			const consoleWarnSpy = vi
-				.spyOn(console, "warn")
-				.mockImplementation(() => void 0)
-			await expect(async () => {
-				await args.run(client)
-			}).rejects.toThrow(prismic.RefNotFoundError)
-			consoleWarnSpy.mockRestore()
+		const consoleWarnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => void 0)
+		await expect(async () => {
+			await args.run(client)
+		}).rejects.toThrow(prismic.RefNotFoundError)
+		consoleWarnSpy.mockRestore()
 
-			expect(triedRefs.length).toBe(3)
-		},
-	)
+		expect(triedRefs.size).toBe(3)
+	})
+
+	it("fetches a new master ref on subsequent queries if an invalid ref is used", async (ctx) => {
+		const client = createTestClient({ ctx })
+		const queryResponse = ctx.mock.api.query({
+			documents: [ctx.mock.value.document()],
+		})
+
+		const triedRefs = new Set<string | null>()
+
+		mockPrismicRestAPIV2({ ctx, queryResponse })
+		const endpoint = new URL(
+			"documents/search",
+			`${client.documentAPIEndpoint}/`,
+		).toString()
+		ctx.server.use(
+			rest.get(endpoint, (req) => {
+				triedRefs.add(req.url.searchParams.get("ref"))
+			}),
+			rest.get(endpoint, (_req, res, requestCtx) =>
+				res.once(
+					requestCtx.json({
+						type: "api_notfound_error",
+						message: `Master ref is: ${ctx.mock.api.ref().ref}`,
+					}),
+					requestCtx.status(404),
+				),
+			),
+		)
+
+		const consoleWarnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => void 0)
+		await args.run(client)
+		consoleWarnSpy.mockRestore()
+
+		await args.run(client)
+
+		expect(triedRefs.size).toBe(3)
+	})
 }

--- a/test/__testutils__/testInvalidRefRetry.ts
+++ b/test/__testutils__/testInvalidRefRetry.ts
@@ -1,0 +1,88 @@
+import { expect, it, vi } from "vitest"
+
+import { rest } from "msw"
+
+import { createTestClient } from "./createClient"
+import { getMasterRef } from "./getMasterRef"
+import { mockPrismicRestAPIV2 } from "./mockPrismicRestAPIV2"
+
+import * as prismic from "../../src"
+
+type TestInvalidRefRetryArgs = {
+	run: (
+		client: prismic.Client,
+		params?: Parameters<prismic.Client["get"]>[0],
+	) => Promise<unknown>
+}
+
+export const testInvalidRefRetry = (
+	description: string,
+	args: TestInvalidRefRetryArgs,
+): void => {
+	it.concurrent(description, async (ctx) => {
+		const client = createTestClient({ ctx })
+
+		const triedRefs: string[] = []
+
+		const repositoryResponse = ctx.mock.api.repository()
+		repositoryResponse.refs = [ctx.mock.api.ref({ isMasterRef: true })]
+
+		const latestRef = ctx.mock.api.ref().ref
+
+		mockPrismicRestAPIV2({ ctx, repositoryResponse })
+
+		const queryEndpoint = new URL(
+			"documents/search",
+			`${client.documentAPIEndpoint}/`,
+		).toString()
+
+		ctx.server.use(
+			rest.get(queryEndpoint, (req, res, ctx) => {
+				const ref = req.url.searchParams.get("ref")
+				if (ref) {
+					triedRefs.push(ref)
+				}
+
+				if (triedRefs.length <= 1) {
+					return res(
+						ctx.status(404),
+						ctx.json({
+							type: "api_notfound_error",
+							message: `Ref not found. Ensure you have the correct ref and try again. Master ref is: ${latestRef}`,
+						}),
+					)
+				}
+			}),
+		)
+
+		const consoleWarnSpy = vi
+			.spyOn(console, "warn")
+			.mockImplementation(() => void 0)
+
+		await args.run(client)
+
+		expect(triedRefs).toStrictEqual([
+			getMasterRef(repositoryResponse),
+			latestRef,
+		])
+
+		// Check that refs are not retried more than once.
+		ctx.server.use(
+			rest.get(queryEndpoint, (_req, res, ctx) => {
+				return res(
+					ctx.status(404),
+					ctx.json({
+						type: "api_notfound_error",
+						message: `Ref not found. Ensure you have the correct ref and try again. Master ref is: ${triedRefs[0]}`,
+					}),
+				)
+			}),
+		)
+
+		await expect(async () => {
+			await args.run(client)
+		}).rejects.toThrow(prismic.RefNotFoundError)
+
+		consoleWarnSpy.mockRestore()
+	})
+}

--- a/test/__testutils__/testInvalidRefRetry.ts
+++ b/test/__testutils__/testInvalidRefRetry.ts
@@ -90,7 +90,7 @@ export const testInvalidRefRetry = (args: TestInvalidRefRetryArgs): void => {
 		expect([...triedRefs]).toStrictEqual([badRef, masterRef])
 	})
 
-	it("throws if the maximum number of retries when an invalid ref is used is reached", async (ctx) => {
+	it("throws if the maximum number of retries with invalid refs is reached", async (ctx) => {
 		const client = createTestClient({ ctx })
 		const queryResponse = ctx.mock.api.query({
 			documents: [ctx.mock.value.document()],

--- a/test/__testutils__/testInvalidRefRetry.ts
+++ b/test/__testutils__/testInvalidRefRetry.ts
@@ -3,10 +3,9 @@ import { expect, it, vi } from "vitest"
 import { rest } from "msw"
 
 import { createTestClient } from "./createClient"
-import { getMasterRef } from "./getMasterRef"
 import { mockPrismicRestAPIV2 } from "./mockPrismicRestAPIV2"
 
-import * as prismic from "../../src"
+import type * as prismic from "../../src"
 
 type TestInvalidRefRetryArgs = {
 	run: (
@@ -15,74 +14,85 @@ type TestInvalidRefRetryArgs = {
 	) => Promise<unknown>
 }
 
-export const testInvalidRefRetry = (
-	description: string,
-	args: TestInvalidRefRetryArgs,
-): void => {
-	it.concurrent(description, async (ctx) => {
-		const client = createTestClient({ ctx })
+export const testInvalidRefRetry = (args: TestInvalidRefRetryArgs): void => {
+	it.concurrent(
+		"retries with the master ref when an invalid ref is used",
+		async (ctx) => {
+			const client = createTestClient({ ctx })
+			const badRef = ctx.mock.api.ref().ref
+			const masterRef = ctx.mock.api.ref().ref
+			const queryResponse = ctx.mock.api.query({
+				documents: [ctx.mock.value.document()],
+			})
 
-		const triedRefs: string[] = []
+			const triedRefs: (string | null)[] = []
 
-		const repositoryResponse = ctx.mock.api.repository()
-		repositoryResponse.refs = [ctx.mock.api.ref({ isMasterRef: true })]
-
-		const latestRef = ctx.mock.api.ref().ref
-
-		mockPrismicRestAPIV2({ ctx, repositoryResponse })
-
-		const queryEndpoint = new URL(
-			"documents/search",
-			`${client.documentAPIEndpoint}/`,
-		).toString()
-
-		ctx.server.use(
-			rest.get(queryEndpoint, (req, res, ctx) => {
-				const ref = req.url.searchParams.get("ref")
-				if (ref) {
-					triedRefs.push(ref)
-				}
-
-				if (triedRefs.length <= 1) {
-					return res(
-						ctx.status(404),
+			mockPrismicRestAPIV2({ ctx, queryResponse })
+			const endpoint = new URL(
+				"documents/search",
+				`${client.documentAPIEndpoint}/`,
+			).toString()
+			ctx.server.use(
+				rest.get(endpoint, (req) => {
+					triedRefs.push(req.url.searchParams.get("ref"))
+				}),
+				rest.get(endpoint, (_req, res, ctx) =>
+					res.once(
 						ctx.json({
 							type: "api_notfound_error",
-							message: `Ref not found. Ensure you have the correct ref and try again. Master ref is: ${latestRef}`,
+							message: `Master ref is: ${masterRef}`,
 						}),
-					)
-				}
-			}),
-		)
+						ctx.status(404),
+					),
+				),
+			)
 
-		const consoleWarnSpy = vi
-			.spyOn(console, "warn")
-			.mockImplementation(() => void 0)
+			const consoleWarnSpy = vi
+				.spyOn(console, "warn")
+				.mockImplementation(() => void 0)
+			await args.run(client, { ref: badRef })
+			consoleWarnSpy.mockRestore()
 
-		await args.run(client)
+			expect(triedRefs).toStrictEqual([badRef, masterRef])
+		},
+	)
 
-		expect(triedRefs).toStrictEqual([
-			getMasterRef(repositoryResponse),
-			latestRef,
-		])
+	it.concurrent(
+		"retries with the master ref when an expired ref is used",
+		async (ctx) => {
+			const client = createTestClient({ ctx })
+			const badRef = ctx.mock.api.ref().ref
+			const masterRef = ctx.mock.api.ref().ref
+			const queryResponse = ctx.mock.api.query({
+				documents: [ctx.mock.value.document()],
+			})
 
-		// Check that refs are not retried more than once.
-		ctx.server.use(
-			rest.get(queryEndpoint, (_req, res, ctx) => {
-				return res(
-					ctx.status(404),
-					ctx.json({
-						type: "api_notfound_error",
-						message: `Ref not found. Ensure you have the correct ref and try again. Master ref is: ${triedRefs[0]}`,
-					}),
-				)
-			}),
-		)
+			const triedRefs: (string | null)[] = []
 
-		await expect(async () => {
-			await args.run(client)
-		}).rejects.toThrow(prismic.RefNotFoundError)
+			mockPrismicRestAPIV2({ ctx, queryResponse })
+			const endpoint = new URL(
+				"documents/search",
+				`${client.documentAPIEndpoint}/`,
+			).toString()
+			ctx.server.use(
+				rest.get(endpoint, (req) => {
+					triedRefs.push(req.url.searchParams.get("ref"))
+				}),
+				rest.get(endpoint, (_req, res, ctx) =>
+					res.once(
+						ctx.json({ message: `Master ref is: ${masterRef}` }),
+						ctx.status(410),
+					),
+				),
+			)
 
-		consoleWarnSpy.mockRestore()
-	})
+			const consoleWarnSpy = vi
+				.spyOn(console, "warn")
+				.mockImplementation(() => void 0)
+			await args.run(client, { ref: badRef })
+			consoleWarnSpy.mockRestore()
+
+			expect(triedRefs).toStrictEqual([badRef, masterRef])
+		},
+	)
 }

--- a/test/client-get.test.ts
+++ b/test/client-get.test.ts
@@ -7,6 +7,7 @@ import { mockPrismicRestAPIV2 } from "./__testutils__/mockPrismicRestAPIV2"
 import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetMethod } from "./__testutils__/testAnyGetMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetMethod("resolves a query", {
 	run: (client) => client.get(),
@@ -90,6 +91,10 @@ it("uses cached repository metadata within the client's repository cache TTL", a
 	expect(new URL(getRequests[1]).searchParams.get("ref")).toBe(
 		repositoryResponse1.refs[0].ref,
 	)
+})
+
+testInvalidRefRetry("retries on expired refs", {
+	run: (client, params) => client.get(params),
 })
 
 testFetchOptions("supports fetch options", {

--- a/test/client-get.test.ts
+++ b/test/client-get.test.ts
@@ -93,7 +93,7 @@ it("uses cached repository metadata within the client's repository cache TTL", a
 	)
 })
 
-testInvalidRefRetry("retries on expired refs", {
+testInvalidRefRetry({
 	run: (client, params) => client.get(params),
 })
 

--- a/test/client-getAllByEveryTag.test.ts
+++ b/test/client-getAllByEveryTag.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetAllMethod("returns all documents by every tag from paginated response", {
 	run: (client) => client.getAllByEveryTag(["foo", "bar"]),
@@ -26,6 +27,10 @@ testGetAllMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByEveryTag(["foo", "bar"], params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getAllByEveryTag(["foo", "bar"], params),
 })
 

--- a/test/client-getAllByIDs.test.ts
+++ b/test/client-getAllByIDs.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetAllMethod("returns all documents by IDs from paginated response", {
 	run: (client) => client.getAllByIDs(["id1", "id2"]),
@@ -26,6 +27,10 @@ testGetAllMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByIDs(["id1", "id2"], params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getAllByIDs(["id1", "id2"], params),
 })
 

--- a/test/client-getAllBySomeTags.test.ts
+++ b/test/client-getAllBySomeTags.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetAllMethod("returns all documents by some tags from paginated response", {
 	run: (client) => client.getAllBySomeTags(["foo", "bar"]),
@@ -26,6 +27,10 @@ testGetAllMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllBySomeTags(["foo", "bar"], params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getAllBySomeTags(["foo", "bar"], params),
 })
 

--- a/test/client-getAllByTag.test.ts
+++ b/test/client-getAllByTag.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetAllMethod("returns all documents by tag from paginated response", {
 	run: (client) => client.getAllByTag("tag"),
@@ -26,6 +27,10 @@ testGetAllMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByTag("tag", params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getAllByTag("tag", params),
 })
 

--- a/test/client-getAllByType.test.ts
+++ b/test/client-getAllByType.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetAllMethod("returns all documents by type from paginated response", {
 	run: (client) => client.getAllByType("type"),
@@ -26,6 +27,10 @@ testGetAllMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getAllByType("type", params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getAllByType("type", params),
 })
 

--- a/test/client-getAllByUIDs.test.ts
+++ b/test/client-getAllByUIDs.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetAllMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetAllMethod("returns all documents by UIDs from paginated response", {
 	run: (client) => client.getAllByUIDs("type", ["uid1", "uid2"]),
@@ -32,6 +33,11 @@ testGetAllMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) =>
+		client.getAllByUIDs("type", ["uid1", "uid2"], params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) =>
 		client.getAllByUIDs("type", ["uid1", "uid2"], params),
 })

--- a/test/client-getByEveryTag.test.ts
+++ b/test/client-getByEveryTag.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetMethod("queries for documents by tag", {
 	run: (client) => client.getByEveryTag(["foo", "bar"]),
@@ -26,6 +27,10 @@ testGetMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByEveryTag(["foo", "bar"], params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getByEveryTag(["foo", "bar"], params),
 })
 

--- a/test/client-getByID.test.ts
+++ b/test/client-getByID.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetFirstMethod("queries for document by ID", {
 	run: (client) => client.getByID("id"),
@@ -26,6 +27,10 @@ testGetFirstMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByID("id", params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getByID("id", params),
 })
 

--- a/test/client-getByIDs.test.ts
+++ b/test/client-getByIDs.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetMethod("queries for documents by IDs", {
 	run: (client) => client.getByIDs(["id1", "id2"]),
@@ -26,6 +27,10 @@ testGetMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByIDs(["id1", "id2"], params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getByIDs(["id1", "id2"], params),
 })
 

--- a/test/client-getBySomeTags.test.ts
+++ b/test/client-getBySomeTags.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetMethod("queries for documents by some tags", {
 	run: (client) => client.getBySomeTags(["foo", "bar"]),
@@ -26,6 +27,10 @@ testGetMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getBySomeTags(["foo", "bar"], params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getBySomeTags(["foo", "bar"], params),
 })
 

--- a/test/client-getByTag.test.ts
+++ b/test/client-getByTag.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetMethod("queries for documents by tag", {
 	run: (client) => client.getByTag("tag"),
@@ -26,6 +27,10 @@ testGetMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByTag("tag", params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getByTag("tag", params),
 })
 

--- a/test/client-getByType.test.ts
+++ b/test/client-getByType.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetMethod("queries for documents by type", {
 	run: (client) => client.getByType("type"),
@@ -26,6 +27,10 @@ testGetMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByType("type", params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getByType("type", params),
 })
 

--- a/test/client-getByUID.test.ts
+++ b/test/client-getByUID.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetFirstMethod("queries for document by UID", {
 	run: (client) => client.getByUID("type", "uid"),
@@ -26,6 +27,10 @@ testGetFirstMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByUID("type", "uid", params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getByUID("type", "uid", params),
 })
 

--- a/test/client-getByUIDs.test.ts
+++ b/test/client-getByUIDs.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetMethod("queries for documents by UIDs", {
 	run: (client) => client.getByUIDs("type", ["uid1", "uid2"]),
@@ -32,6 +33,10 @@ testGetMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getByUIDs("type", ["uid1", "uid2"], params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getByUIDs("type", ["uid1", "uid2"], params),
 })
 

--- a/test/client-getFirst.test.ts
+++ b/test/client-getFirst.test.ts
@@ -8,6 +8,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 import * as prismic from "../src"
 
@@ -95,6 +96,10 @@ it("throws if no documents were returned", async (ctx) => {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getFirst(params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getFirst(params),
 })
 

--- a/test/client-getSingle.test.ts
+++ b/test/client-getSingle.test.ts
@@ -2,6 +2,7 @@ import { testAbortableMethod } from "./__testutils__/testAbortableMethod"
 import { testGetFirstMethod } from "./__testutils__/testAnyGetMethod"
 import { testConcurrentMethod } from "./__testutils__/testConcurrentMethod"
 import { testFetchOptions } from "./__testutils__/testFetchOptions"
+import { testInvalidRefRetry } from "./__testutils__/testInvalidRefRetry"
 
 testGetFirstMethod("queries for singleton document", {
 	run: (client) => client.getSingle("type"),
@@ -26,6 +27,10 @@ testGetFirstMethod("includes params if provided", {
 })
 
 testFetchOptions("supports fetch options", {
+	run: (client, params) => client.getSingle("type", params),
+})
+
+testInvalidRefRetry({
 	run: (client, params) => client.getSingle("type", params),
 })
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: #333

### Description

This PR adds a retry mechanism when a `RefNotFoundError` or `RefExpiredError` is thrown in a query method. The client will retry a maximum of 3 times before throwing.

A warning is logged when retrying:

```ts
"The ref (xxx) was expired. Now retrying with the latest master ref (yyy). If you were previewing content, the response will not include draft content."
```

This PR also clears the `/api/v2` value cached for 5s when we know a stale value is saved. This prevents a small edge case where calls within 5s would have all failed if the ref was invalid or expired.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

There are no changes to existing code. Queries appear as before.

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

See the tests.

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
