### PR TITLE
feat: support link variant for migration client

### DIFF
--- a/src/Migration.ts
+++ b/src/Migration.ts
@@ -411,6 +411,7 @@ export class Migration<TDocuments extends PrismicDocument = PrismicDocument> {
 					id: "_____broken_____",
 					isBroken: true,
 					text: input.text,
+					variant: input.variant,
 				}
 			}
 
@@ -418,6 +419,7 @@ export class Migration<TDocuments extends PrismicDocument = PrismicDocument> {
 				link_type: LinkType.Document,
 				id: () => this._getByOriginalID(input.id),
 				text: input.text,
+				variant: input.variant,
 			}
 		}
 
@@ -426,6 +428,7 @@ export class Migration<TDocuments extends PrismicDocument = PrismicDocument> {
 				link_type: LinkType.Media,
 				id: this.createAsset(input),
 				text: input.text,
+				variant: input.variant,
 			}
 		}
 

--- a/src/lib/resolveMigrationDocumentData.ts
+++ b/src/lib/resolveMigrationDocumentData.ts
@@ -54,7 +54,13 @@ export async function resolveMigrationContentRelationship(
 			}
 		}
 
-		return { link_type: LinkType.Document, id: relation.id }
+		// This is only called when resolveMigrationContentRelationship recursively
+		// calls itself from the statement above and the resolved content relation
+		// is a Prismic document value.
+		return {
+			link_type: LinkType.Document,
+			id: relation.id,
+		}
 	}
 
 	return { link_type: LinkType.Document }

--- a/src/lib/resolveMigrationDocumentData.ts
+++ b/src/lib/resolveMigrationDocumentData.ts
@@ -48,9 +48,9 @@ export async function resolveMigrationContentRelationship(
 		) {
 			return {
 				...(await resolveMigrationContentRelationship(relation.id)),
-				// TODO: Remove when link text PR is merged
-				// @ts-expect-error - Future-proofing for link text
-				text: relation.text,
+				...("text" in relation && relation.text && { text: relation.text }),
+				...("variant" in relation &&
+					relation.variant && { variant: relation.variant }),
 			}
 		}
 
@@ -164,6 +164,7 @@ export const resolveMigrationLinkToMedia = (
 			id: asset.id,
 			link_type: LinkType.Media,
 			text: linkToMedia.text,
+			variant: linkToMedia.variant,
 		}
 	}
 

--- a/src/types/migration/Asset.ts
+++ b/src/types/migration/Asset.ts
@@ -75,7 +75,7 @@ export type MigrationLinkToMedia = Pick<
 	LinkToMediaField<"filled">,
 	"link_type"
 > &
-	Partial<Pick<LinkToMediaField<"filled">, "text">> & {
+	Partial<Pick<LinkToMediaField<"filled">, "text" | "variant">> & {
 		/**
 		 * A reference to the migration asset used to resolve the link to media
 		 * field's value.
@@ -88,7 +88,7 @@ export type MigrationLinkToMedia = Pick<
  * with the migration API.
  */
 export type MigrationLinkToMediaField =
-	| Pick<LinkToMediaField<"filled">, "link_type" | "id" | "text">
+	| Pick<LinkToMediaField<"filled">, "link_type" | "id" | "text" | "variant">
 	| EmptyLinkField<"Media">
 
 /**

--- a/src/types/migration/ContentRelationship.ts
+++ b/src/types/migration/ContentRelationship.ts
@@ -14,7 +14,7 @@ export type MigrationContentRelationship<
 > =
 	| ValueOrThunk<TDocuments | PrismicMigrationDocument<TDocuments> | undefined>
 	| (Pick<FilledContentRelationshipField, "link_type"> &
-			Partial<Pick<FilledContentRelationshipField, "text">> & {
+			Partial<Pick<FilledContentRelationshipField, "text" | "variant">> & {
 				id: ValueOrThunk<
 					TDocuments | PrismicMigrationDocument<TDocuments> | undefined
 				>

--- a/test/__snapshots__/writeClient-migrate-patch-contentRelationship.test.ts.snap
+++ b/test/__snapshots__/writeClient-migrate-patch-contentRelationship.test.ts.snap
@@ -266,6 +266,97 @@ exports[`patches content relationship fields (from Prismic) > withText > static 
 }
 `;
 
+exports[`patches content relationship fields (from Prismic) > withVariant > group 1`] = `
+{
+  "group": [
+    {
+      "field": {
+        "id": "other.id-fromPrismic",
+        "link_type": "Document",
+        "variant": "Secondary",
+      },
+    },
+  ],
+}
+`;
+
+exports[`patches content relationship fields (from Prismic) > withVariant > shared slice 1`] = `
+{
+  "slices": [
+    {
+      "id": "9b9dd0f2c3f",
+      "items": [
+        {
+          "field": {
+            "id": "other.id-fromPrismic",
+            "link_type": "Document",
+            "variant": "Secondary",
+          },
+        },
+      ],
+      "primary": {
+        "field": {
+          "id": "other.id-fromPrismic",
+          "link_type": "Document",
+          "variant": "Secondary",
+        },
+        "group": [
+          {
+            "field": {
+              "id": "other.id-fromPrismic",
+              "link_type": "Document",
+              "variant": "Secondary",
+            },
+          },
+        ],
+      },
+      "slice_label": null,
+      "slice_type": "nunc",
+      "variation": "ullamcorper",
+      "version": "8bfc905",
+    },
+  ],
+}
+`;
+
+exports[`patches content relationship fields (from Prismic) > withVariant > slice 1`] = `
+{
+  "slices": [
+    {
+      "id": "5306297c5ed",
+      "items": [
+        {
+          "field": {
+            "id": "other.id-fromPrismic",
+            "link_type": "Document",
+            "variant": "Secondary",
+          },
+        },
+      ],
+      "primary": {
+        "field": {
+          "id": "other.id-fromPrismic",
+          "link_type": "Document",
+          "variant": "Secondary",
+        },
+      },
+      "slice_label": "Vel",
+      "slice_type": "hac_habitasse",
+    },
+  ],
+}
+`;
+
+exports[`patches content relationship fields (from Prismic) > withVariant > static zone 1`] = `
+{
+  "field": {
+    "id": "other.id-fromPrismic",
+    "link_type": "Document",
+    "variant": "Secondary",
+  },
+}
+`;
+
 exports[`patches content relationship fields > existing > group 1`] = `
 {
   "group": [
@@ -521,6 +612,97 @@ exports[`patches content relationship fields > existingLongFormWithText > static
     "id": "other.id-existing",
     "link_type": "Document",
     "text": "foo",
+  },
+}
+`;
+
+exports[`patches content relationship fields > existingLongFormWithVariant > group 1`] = `
+{
+  "group": [
+    {
+      "field": {
+        "id": "other.id-existing",
+        "link_type": "Document",
+        "variant": "Secondary",
+      },
+    },
+  ],
+}
+`;
+
+exports[`patches content relationship fields > existingLongFormWithVariant > shared slice 1`] = `
+{
+  "slices": [
+    {
+      "id": "9b9dd0f2c3f",
+      "items": [
+        {
+          "field": {
+            "id": "other.id-existing",
+            "link_type": "Document",
+            "variant": "Secondary",
+          },
+        },
+      ],
+      "primary": {
+        "field": {
+          "id": "other.id-existing",
+          "link_type": "Document",
+          "variant": "Secondary",
+        },
+        "group": [
+          {
+            "field": {
+              "id": "other.id-existing",
+              "link_type": "Document",
+              "variant": "Secondary",
+            },
+          },
+        ],
+      },
+      "slice_label": null,
+      "slice_type": "nunc",
+      "variation": "ullamcorper",
+      "version": "8bfc905",
+    },
+  ],
+}
+`;
+
+exports[`patches content relationship fields > existingLongFormWithVariant > slice 1`] = `
+{
+  "slices": [
+    {
+      "id": "5306297c5ed",
+      "items": [
+        {
+          "field": {
+            "id": "other.id-existing",
+            "link_type": "Document",
+            "variant": "Secondary",
+          },
+        },
+      ],
+      "primary": {
+        "field": {
+          "id": "other.id-existing",
+          "link_type": "Document",
+          "variant": "Secondary",
+        },
+      },
+      "slice_label": "Vel",
+      "slice_type": "hac_habitasse",
+    },
+  ],
+}
+`;
+
+exports[`patches content relationship fields > existingLongFormWithVariant > static zone 1`] = `
+{
+  "field": {
+    "id": "other.id-existing",
+    "link_type": "Document",
+    "variant": "Secondary",
   },
 }
 `;

--- a/test/writeClient-migrate-patch-contentRelationship.test.ts
+++ b/test/writeClient-migrate-patch-contentRelationship.test.ts
@@ -25,6 +25,13 @@ testMigrationFieldPatching<
 			text: "foo",
 		}
 	},
+	existingLongFormWithVariant: ({ existingDocuments }) => {
+		return {
+			link_type: LinkType.Document,
+			id: existingDocuments[0],
+			variant: "Secondary",
+		}
+	},
 	otherCreate: ({ otherCreateDocument }) => otherCreateDocument,
 	lazyExisting: ({ existingDocuments }) => {
 		return () => existingDocuments[0]
@@ -89,6 +96,19 @@ testMigrationFieldPatching<ContentRelationshipField>(
 			return {
 				...contentRelationship,
 				text: "foo",
+			}
+		},
+		withVariant: ({ ctx, otherFromPrismicDocument }) => {
+			const contentRelationship = ctx.mock.value.link({
+				type: LinkType.Document,
+			})
+			// `migrationDocuments` contains documents from "another repository"
+			contentRelationship.id =
+				otherFromPrismicDocument.originalPrismicDocument!.id
+
+			return {
+				...contentRelationship,
+				variant: "Secondary",
 			}
 		},
 		broken: () => {

--- a/test/writeClient-migrate-patch-contentRelationship.test.ts
+++ b/test/writeClient-migrate-patch-contentRelationship.test.ts
@@ -86,11 +86,10 @@ testMigrationFieldPatching<ContentRelationshipField>(
 			contentRelationship.id =
 				otherFromPrismicDocument.originalPrismicDocument!.id
 
-			// TODO: Remove when link text PR is merged
-			// @ts-expect-error - Future-proofing for link text
-			contentRelationship.text = "foo"
-
-			return contentRelationship
+			return {
+				...contentRelationship,
+				text: "foo",
+			}
 		},
 		broken: () => {
 			return {


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2476: AAUser I can use the Migration API client to migrate documents that contain links with variants](https://linear.app/prismic/issue/DT-2476/aauser-i-can-use-the-migration-api-client-to-migrate-documents-that)

### Description

- Remove some TODO that we forgot before
- Add support for link variant in migration api client

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
