### PR TITLE
fix: fix link types value + model

### DIFF
--- a/src/types/model/contentRelationship.ts
+++ b/src/types/model/contentRelationship.ts
@@ -18,6 +18,5 @@ export interface CustomTypeModelContentRelationshipField<
 		select: typeof CustomTypeModelLinkSelectType.Document
 		customtypes?: readonly CustomTypeIDs[]
 		tags?: readonly Tags[]
-		allowText?: boolean
 	}
 }

--- a/src/types/model/linkToMedia.ts
+++ b/src/types/model/linkToMedia.ts
@@ -14,5 +14,6 @@ export interface CustomTypeModelLinkToMediaField {
 		placeholder?: string
 		select: typeof CustomTypeModelLinkSelectType.Media
 		allowText?: boolean
+		variants?: string[]
 	}
 }

--- a/src/types/value/contentRelationship.ts
+++ b/src/types/value/contentRelationship.ts
@@ -1,7 +1,7 @@
 import type { AnyRegularField, FieldState } from "./types"
 
 import type { GroupField } from "./group"
-import type { EmptyLinkField, LinkType } from "./link"
+import type { EmptyLinkField, LinkType, WithLinkAdditionalData } from "./link"
 import type { SliceZone } from "./sliceZone"
 
 /**
@@ -22,18 +22,21 @@ export type ContentRelationshipField<
 	State extends FieldState = FieldState,
 > = State extends "empty"
 	? EmptyLinkField<typeof LinkType.Document>
-	: FilledContentRelationshipField<TypeEnum, LangEnum, DataInterface>
+	: Omit<
+			FilledContentRelationshipField<TypeEnum, LangEnum, DataInterface>,
+			"text" | "variant"
+		>
 
 /**
  * Links that refer to documents
  */
-export interface FilledContentRelationshipField<
+export type FilledContentRelationshipField<
 	TypeEnum = string,
 	LangEnum = string,
 	DataInterface extends
 		| Record<string, AnyRegularField | GroupField | SliceZone>
 		| unknown = unknown,
-> {
+> = WithLinkAdditionalData<{
 	link_type: typeof LinkType.Document
 	id: string
 	uid?: string
@@ -44,6 +47,4 @@ export interface FilledContentRelationshipField<
 	slug?: string
 	isBroken?: boolean
 	data?: DataInterface
-	text?: string
-	variant?: string
-}
+}>

--- a/src/types/value/link.ts
+++ b/src/types/value/link.ts
@@ -16,6 +16,16 @@ export const LinkType = {
 } as const
 
 /**
+ * Additional optional data for a link field.
+ *
+ * @typeParam Link - Link field.
+ */
+export type WithLinkAdditionalData<Link> = Link & {
+	text?: string
+	variant?: string
+}
+
+/**
  * For link fields that haven't been filled
  *
  * @typeParam Type - The type of link.
@@ -24,20 +34,16 @@ export type EmptyLinkField<
 	Type extends (typeof LinkType)[keyof typeof LinkType] = typeof LinkType.Any,
 > = {
 	link_type: Type | string
-	text?: string
-	variant?: string
 }
 
 /**
  * Link that points to external website
  */
-export interface FilledLinkToWebField {
+export type FilledLinkToWebField = WithLinkAdditionalData<{
 	link_type: typeof LinkType.Web
 	url: string
 	target?: string
-	text?: string
-	variant?: string
-}
+}>
 
 /**
  * A link field.
@@ -56,8 +62,10 @@ export type LinkField<
 		| unknown = unknown,
 	State extends FieldState = FieldState,
 > = State extends "empty"
-	? EmptyLinkField<typeof LinkType.Any>
+	? WithLinkAdditionalData<EmptyLinkField<typeof LinkType.Any>>
 	:
-			| ContentRelationshipField<TypeEnum, LangEnum, DataInterface, State>
+			| WithLinkAdditionalData<
+					ContentRelationshipField<TypeEnum, LangEnum, DataInterface, State>
+			  >
 			| FilledLinkToWebField
 			| LinkToMediaField<State>

--- a/src/types/value/linkToMedia.ts
+++ b/src/types/value/linkToMedia.ts
@@ -1,6 +1,6 @@
 import type { FieldState } from "./types"
 
-import type { EmptyLinkField, LinkType } from "./link"
+import type { EmptyLinkField, LinkType, WithLinkAdditionalData } from "./link"
 
 /**
  * A link field that points to media.
@@ -9,13 +9,13 @@ import type { EmptyLinkField, LinkType } from "./link"
  */
 export type LinkToMediaField<State extends FieldState = FieldState> =
 	State extends "empty"
-		? EmptyLinkField<typeof LinkType.Media>
+		? WithLinkAdditionalData<EmptyLinkField<typeof LinkType.Media>>
 		: FilledLinkToMediaField
 
 /**
  * A link that points to media.
  */
-export interface FilledLinkToMediaField {
+export type FilledLinkToMediaField = WithLinkAdditionalData<{
 	id: string
 	link_type: typeof LinkType.Media
 	name: string
@@ -24,6 +24,4 @@ export interface FilledLinkToMediaField {
 	size: string
 	height?: string | null
 	width?: string | null
-	text?: string
-	variant?: string
-}
+}>

--- a/src/types/value/richText.ts
+++ b/src/types/value/richText.ts
@@ -177,9 +177,9 @@ export type RTImageNode = {
 		background: string
 	}
 	linkTo?:
-		| FilledContentRelationshipField
-		| FilledLinkToWebField
-		| FilledLinkToMediaField
+		| Omit<FilledContentRelationshipField, "text" | "variant">
+		| Omit<FilledLinkToWebField, "text" | "variant">
+		| Omit<FilledLinkToMediaField, "text" | "variant">
 }
 
 /**
@@ -200,9 +200,9 @@ export type RTEmbedNode = {
 export interface RTLinkNode extends RTSpanNodeBase {
 	type: typeof RichTextNodeType.hyperlink
 	data:
-		| FilledContentRelationshipField
-		| FilledLinkToWebField
-		| FilledLinkToMediaField
+		| Omit<FilledContentRelationshipField, "text" | "variant">
+		| Omit<FilledLinkToWebField, "text" | "variant">
+		| Omit<FilledLinkToMediaField, "text" | "variant">
 }
 
 // Serialization related nodes

--- a/test/types/customType-contentRelationship.types.ts
+++ b/test/types/customType-contentRelationship.types.ts
@@ -97,18 +97,6 @@ expectType<prismic.CustomTypeModelContentRelationshipField<string, "foo">>({
 })
 
 /**
- * Supports optional `allowText` property.
- */
-expectType<prismic.CustomTypeModelContentRelationshipField<string, "foo">>({
-	type: prismic.CustomTypeModelFieldType.Link,
-	config: {
-		label: "string",
-		select: prismic.CustomTypeModelLinkSelectType.Document,
-		allowText: true,
-	},
-})
-
-/**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelContentRelationshipField>(

--- a/test/types/customType-linkToMedia.types.ts
+++ b/test/types/customType-linkToMedia.types.ts
@@ -53,6 +53,18 @@ expectType<prismic.CustomTypeModelLinkToMediaField>({
 })
 
 /**
+ * Supports optional `variants` property.
+ */
+expectType<prismic.CustomTypeModelLinkToMediaField>({
+	type: prismic.CustomTypeModelFieldType.Link,
+	config: {
+		label: "string",
+		select: prismic.CustomTypeModelLinkSelectType.Media,
+		variants: ["string"],
+	},
+})
+
+/**
  * `@prismicio/types` extends `@prismicio/types-internal`
  */
 expectType<prismic.CustomTypeModelLinkToMediaField>(

--- a/test/types/fields-contentRelationship.types.ts
+++ b/test/types/fields-contentRelationship.types.ts
@@ -32,8 +32,6 @@ expectType<prismic.ContentRelationshipField>({
 	slug: "string",
 	isBroken: true,
 	data: undefined,
-	text: "string",
-	variant: "string",
 })
 expectType<prismic.ContentRelationshipField<string, string, never, "filled">>({
 	link_type: prismic.LinkType.Document,
@@ -46,8 +44,6 @@ expectType<prismic.ContentRelationshipField<string, string, never, "filled">>({
 	slug: "string",
 	isBroken: true,
 	data: undefined,
-	text: "string",
-	variant: "string",
 })
 expectType<prismic.ContentRelationshipField<string, string, never, "empty">>({
 	link_type: prismic.LinkType.Document,
@@ -61,8 +57,6 @@ expectType<prismic.ContentRelationshipField<string, string, never, "empty">>({
 	slug: "string",
 	isBroken: true,
 	data: undefined,
-	text: "string",
-	variant: "string",
 })
 
 /**
@@ -78,28 +72,6 @@ expectType<prismic.ContentRelationshipField<string, string, never, "filled">>(
 	// @ts-expect-error - Filled fields cannot contain an empty value.
 	{
 		link_type: prismic.LinkType.Document,
-	},
-)
-
-/**
- * Empty state with text and variant.
- */
-expectType<prismic.ContentRelationshipField>({
-	link_type: prismic.LinkType.Document,
-	text: "string",
-	variant: "string",
-})
-expectType<prismic.ContentRelationshipField<string, string, never, "empty">>({
-	link_type: prismic.LinkType.Document,
-	text: "string",
-	variant: "string",
-})
-expectType<prismic.ContentRelationshipField<string, string, never, "filled">>(
-	// @ts-expect-error - Filled fields cannot contain an empty value.
-	{
-		link_type: prismic.LinkType.Document,
-		text: "string",
-		variant: "string",
 	},
 )
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

### Description

This PR objective is to clean up and fix the link types (model + value).

This PR initially assumes that we will support `allowText` and `variants` for Link To Media and Generic Link.
We are waiting for a final product decision and, of course, this will impact the code if we decide to drop support, as it's the case for Content Relationship.

**Model**

- `allowText` should not be defined on Content Relationship
- `variants` should be defined for Link To Media.

**Value**

- Ensure all `Filled` links have text and variants as they are re-used everywhere to define what a link even coming from a generic link can be.
- Ensure `EmptyLinkField` doesn't by default have `text` and `variant` as it's used in `ContentRelationshipField`
- Omit `text` and `variant` manually when types are used for Rich Text

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
