### PR TITLE
fix: allow "page" param to properly pass through getall methods

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -605,6 +605,7 @@ export class Client<
 	): Promise<TDocument[]> {
 		const { limit = Infinity, ...actualParams } = params
 		const resolvedParams = {
+			page: undefined,
 			...actualParams,
 			pageSize: Math.min(
 				limit,
@@ -619,7 +620,7 @@ export class Client<
 			(!latestResult || latestResult.next_page) &&
 			documents.length < limit
 		) {
-			const page = latestResult ? latestResult.page + 1 : undefined
+			const page = latestResult ? latestResult.page + 1 : resolvedParams.page
 
 			latestResult = await this.get<TDocument>({ ...resolvedParams, page })
 			documents.push(...latestResult.results)

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -599,9 +599,7 @@ export class Client<
 	 * @returns A list of documents matching the query.
 	 */
 	async dangerouslyGetAll<TDocument extends TDocuments>(
-		params: Partial<Omit<BuildQueryURLArgs, "page">> &
-			GetAllParams &
-			FetchParams = {},
+		params: Partial<BuildQueryURLArgs> & GetAllParams & FetchParams = {},
 	): Promise<TDocument[]> {
 		const { limit = Infinity, ...actualParams } = params
 		const resolvedParams = {


### PR DESCRIPTION
**Resolves**: #369

### Description

The `dangerouslyGetAll` method (and all `getAll*` methods utilizing it) now uses the `page` param passed in as the starting point for its search results instead of only searching from the first page.
 
This fixes the offset pagination for the client without having to directly create and send out API requests with `fetch()`.

### Checklist

No existing tests fail as a result of this change.

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### How to QA [^1]

Utilize the snippet of code provided in the original issue on the new client.

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->
Changes have not yet been tested on a real Prismic project. The code was read and traced through line by line.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
