### PR TITLE
fix: export table field types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,16 @@ export type {
 	EmbedField,
 } from "./types/value/embed"
 
+export type {
+	TableField,
+	TableFieldHead,
+	TableFieldHeadRow,
+	TableFieldBody,
+	TableFieldBodyRow,
+	TableFieldHeaderCell,
+	TableFieldDataCell,
+} from "./types/value/table"
+
 export type { BooleanField } from "./types/value/boolean"
 export type { ColorField } from "./types/value/color"
 export type { DateField } from "./types/value/date"
@@ -227,7 +237,6 @@ export type { NumberField } from "./types/value/number"
 export type { SelectField } from "./types/value/select"
 export type { TimestampField } from "./types/value/timestamp"
 export type { GeoPointField } from "./types/value/geoPoint"
-export type { TableField } from "./types/value/table"
 
 /**
  * @deprecated Renamed to `IntegrationField`

--- a/src/types/value/table.ts
+++ b/src/types/value/table.ts
@@ -14,33 +14,44 @@ export type TableField<State extends FieldState = FieldState> =
 		? null
 		: {
 				/**
-				 * The header of the table.
+				 * The head of the table.
 				 */
-				head?: {
-					rows: TableHeaderRow[]
-				}
+				head?: TableFieldHead
+
 				/**
 				 * The body of the table.
 				 */
-				body: {
-					rows: TableDataRow[]
-				}
+				body: TableFieldBody
 			}
 
 /**
- * Represents a row in a table header.
+ * Represents a table head.
  */
-export type TableHeaderRow = {
-	/**
-	 * Cells in the row.
-	 */
-	cells: TableHeaderCell[]
+export type TableFieldHead = {
+	rows: TableFieldHeadRow[]
 }
 
 /**
- * Represents a cell in a table header.
+ * Represents a table body.
  */
-export type TableHeaderCell = {
+export type TableFieldBody = {
+	rows: TableFieldBodyRow[]
+}
+
+/**
+ * Represents a row in a table head.
+ */
+export type TableFieldHeadRow = {
+	/**
+	 * Cells in the row.
+	 */
+	cells: TableFieldHeaderCell[]
+}
+
+/**
+ * Represents a table header cell.
+ */
+export type TableFieldHeaderCell = {
 	type: "header"
 	content: RichTextField
 }
@@ -48,17 +59,17 @@ export type TableHeaderCell = {
 /**
  * Represents a row in a table body.
  */
-export type TableDataRow = {
+export type TableFieldBodyRow = {
 	/**
 	 * Cells in the row.
 	 */
-	cells: (TableHeaderCell | TableDataCell)[]
+	cells: (TableFieldHeaderCell | TableFieldDataCell)[]
 }
 
 /**
- * Represents a cell in a table body.
+ * Represents a table data cell.
  */
-export type TableDataCell = {
+export type TableFieldDataCell = {
 	type: "data"
 	content: RichTextField
 }

--- a/src/types/value/types.ts
+++ b/src/types/value/types.ts
@@ -13,6 +13,7 @@ import type { LinkToMediaField } from "./linkToMedia"
 import type { NumberField } from "./number"
 import type { RichTextField } from "./richText"
 import type { SelectField } from "./select"
+import type { TableField } from "./table"
 import type { TimestampField } from "./timestamp"
 import type { TitleField } from "./title"
 
@@ -47,6 +48,7 @@ export type AnyRegularField =
 	| BooleanField
 	| GeoPointField
 	| IntegrationField
+	| TableField
 
 /**
  * Any field that can be used in a slice's primary section.


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: N/A

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR exports types related to table fields. `TableField` was already exported, but none of its subtypes were, like `TableFieldDataCell`. The subtypes are helpful in higher-level packages, like `@prismicio/react` and `@prismicio/svelte`.

This PR also updates some of the types with proper namespacing and more accurate descriptions. Because the table field is not publicly available yet, these changes are not considered breaking.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
