### PR TITLE
feat: support key for table field content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [7.17.0-alpha.0](https://github.com/prismicio/prismic-client/compare/v7.15.0...v7.17.0-alpha.0) (2025-03-18)
+
+
+### Features
+
+* add TableField to AnyRegularField ([6f249d0](https://github.com/prismicio/prismic-client/commit/6f249d06c572f2ef09a2e253743e1045ebc2e8dc))
+* support key for table field content ([165abef](https://github.com/prismicio/prismic-client/commit/165abef574729c77a63cbd3929cac08ae630e82b))
+* support table field ([#375](https://github.com/prismicio/prismic-client/issues/375)) ([39c66f0](https://github.com/prismicio/prismic-client/commit/39c66f09d9f6d7f84ca0b628a7cb0376372ca999))
+
+
+### Bug Fixes
+
+* allow generics with link variant ([#374](https://github.com/prismicio/prismic-client/issues/374)) ([7cff55e](https://github.com/prismicio/prismic-client/commit/7cff55e582458964353ac650346cbb0471a500ba))
+* export table field types ([a0f3e44](https://github.com/prismicio/prismic-client/commit/a0f3e44d514808f9f0ffc2acc9a1adc29323eea7))
+* export table field types ([2862321](https://github.com/prismicio/prismic-client/commit/2862321a186a3f4f617c018977e83dd001666267))
+
+
+### Chore
+
+* **release:** 7.15.1 ([c54c749](https://github.com/prismicio/prismic-client/commit/c54c7495dd748239e0ee615723ec9456204ea07a))
+* **release:** 7.16.0 ([821b360](https://github.com/prismicio/prismic-client/commit/821b3606c7a736971d219a33dbfa9032aa2cd7bf))
+* **release:** 7.16.1 ([16d066f](https://github.com/prismicio/prismic-client/commit/16d066fab315896b099929c1305e46d8bff93565))
+* update prismic-mock dep ([d5d7edb](https://github.com/prismicio/prismic-client/commit/d5d7edb23a491823766036d582969cdb4faeeba8))
+* update prismic-mock dep ([dbf56e6](https://github.com/prismicio/prismic-client/commit/dbf56e603ecb3507a30f4948c1454b142e3104d3))
+* update prismic-mock dep ([361b882](https://github.com/prismicio/prismic-client/commit/361b882c0f74627bd845d9146d4fb6aa0b65b49d))
+
 ### [7.16.1](https://github.com/prismicio/prismic-client/compare/v7.16.0...v7.16.1) (2025-02-20)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@prismicio/client",
-	"version": "7.16.1",
+	"version": "7.17.0-alpha.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@prismicio/client",
-			"version": "7.16.1",
+			"version": "7.17.0-alpha.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"imgix-url-builder": "^0.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@prismicio/client",
-	"version": "7.16.1",
+	"version": "7.17.0-alpha.0",
 	"description": "The official JavaScript + TypeScript client library for Prismic",
 	"keywords": [
 		"typescript",

--- a/src/types/value/table.ts
+++ b/src/types/value/table.ts
@@ -43,7 +43,7 @@ export type TableFieldBody = {
  */
 export type TableFieldHeadRow = {
 	/**
-	 * Unique key of the row (UUID v4 format).
+	 * Unique key of the row.
 	 */
 	key: string
 
@@ -58,7 +58,7 @@ export type TableFieldHeadRow = {
  */
 export type TableFieldHeaderCell = {
 	/**
-	 * Unique key of the cell (UUID v4 format).
+	 * Unique key of the cell.
 	 */
 	key: string
 
@@ -78,7 +78,7 @@ export type TableFieldHeaderCell = {
  */
 export type TableFieldBodyRow = {
 	/**
-	 * Unique key of the row (UUID v4 format).
+	 * Unique key of the row.
 	 */
 	key: string
 
@@ -93,7 +93,7 @@ export type TableFieldBodyRow = {
  */
 export type TableFieldDataCell = {
 	/**
-	 * Unique key of the cell (UUID v4 format).
+	 * Unique key of the cell.
 	 */
 	key: string
 

--- a/src/types/value/table.ts
+++ b/src/types/value/table.ts
@@ -43,6 +43,11 @@ export type TableFieldBody = {
  */
 export type TableFieldHeadRow = {
 	/**
+	 * Unique key of the row (UUID v4 format).
+	 */
+	key: string
+
+	/**
 	 * Cells in the row.
 	 */
 	cells: TableFieldHeaderCell[]
@@ -52,7 +57,19 @@ export type TableFieldHeadRow = {
  * Represents a table header cell.
  */
 export type TableFieldHeaderCell = {
+	/**
+	 * Unique key of the cell (UUID v4 format).
+	 */
+	key: string
+
+	/**
+	 * The type of the cell.
+	 */
 	type: "header"
+
+	/**
+	 * The content of the cell.
+	 */
 	content: RichTextField
 }
 
@@ -60,6 +77,11 @@ export type TableFieldHeaderCell = {
  * Represents a row in a table body.
  */
 export type TableFieldBodyRow = {
+	/**
+	 * Unique key of the row (UUID v4 format).
+	 */
+	key: string
+
 	/**
 	 * Cells in the row.
 	 */
@@ -70,6 +92,18 @@ export type TableFieldBodyRow = {
  * Represents a table data cell.
  */
 export type TableFieldDataCell = {
+	/**
+	 * Unique key of the cell (UUID v4 format).
+	 */
+	key: string
+
+	/**
+	 * The type of the cell.
+	 */
 	type: "data"
+
+	/**
+	 * The content of the cell.
+	 */
 	content: RichTextField
 }

--- a/test/types/fields-table.types.ts
+++ b/test/types/fields-table.types.ts
@@ -25,8 +25,10 @@ expectType<prismic.TableField>({
 	head: {
 		rows: [
 			{
+				key: "string",
 				cells: [
 					{
+						key: "string",
 						type: "header",
 						content: [
 							{
@@ -49,8 +51,10 @@ expectType<prismic.TableField>({
 	body: {
 		rows: [
 			{
+				key: "string",
 				cells: [
 					{
+						key: "string",
 						type: "data",
 						content: [
 							{


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: [DT-2635: \[S\] AADev, I can use the key for each row and cell as a unique identifier](https://linear.app/prismic/issue/DT-2635/[s]-aadev-i-can-use-the-key-for-each-row-and-cell-as-a-unique)

### Description

- We need to have a unique key for each row and cell. This would allow us and user to easily map over rows and cells having a unique identifier and prevent hacky things like `JSON.stringify` or using `index`.

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
