### PR TITLE
fix: prevent logging the retry message many times

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -8,6 +8,7 @@ import { findRefByLabel } from "./lib/findRefByLabel"
 import { getPreviewCookie } from "./lib/getPreviewCookie"
 import { minifyGraphQLQuery } from "./lib/minifyGraphQLQuery"
 import { someTagsFilter } from "./lib/someTagsFilter"
+import { throttledLog } from "./lib/throttledLog"
 import { typeFilter } from "./lib/typeFilter"
 
 import type { Query } from "./types/api/query"
@@ -1737,8 +1738,9 @@ export class Client<
 
 			const badRef = new URL(url).searchParams.get("ref")
 			const issue = error instanceof RefNotFoundError ? "invalid" : "expired"
-			console.warn(
-				`The ref (${badRef}) was ${issue}. Now retrying with the latest master ref (${masterRef}). If you were previewing content, the response will not include draft content.`,
+			throttledLog(
+				`[@prismicio/client] The ref (${badRef}) was ${issue}. Now retrying with the latest master ref (${masterRef}). If you were previewing content, the response will not include draft content.`,
+				{ level: "warn" },
 			)
 
 			return await this._get({ ...params, ref: masterRef }, attemptCount + 1)

--- a/src/lib/throttledLog.ts
+++ b/src/lib/throttledLog.ts
@@ -23,15 +23,16 @@ export const throttledLog = (
 ): void => {
 	const { level = "log" } = config
 
-	lastCalledAt = Date.now()
-
 	if (
 		message === lastMessage &&
 		Date.now() - lastCalledAt < THROTTLE_THRESHOLD_MS
 	) {
+		lastCalledAt = Date.now()
+
 		return
 	}
 
+	lastCalledAt = Date.now()
 	lastMessage = message
 
 	// eslint-disable-next-line no-console

--- a/src/lib/throttledLog.ts
+++ b/src/lib/throttledLog.ts
@@ -1,0 +1,39 @@
+const THROTTLE_THRESHOLD_MS = 5000
+
+let lastMessage: string | undefined
+let lastCalledAt = 0
+
+/**
+ * Logs a message. If the message is identical the immediate previous logged
+ * message and that message was logged within 5 seconds of the current call, the
+ * log is ignored. This throttle behavior prevents identical messages from
+ * flodding the console.
+ *
+ * @param message - A message to log.
+ * @param config - Configuration for the log.
+ */
+export const throttledLog = (
+	message: string,
+	config: {
+		/**
+		 * The log level. Matches the global `console` log levels.
+		 */
+		level?: "log" | "warn" | "error"
+	} = {},
+): void => {
+	const { level = "log" } = config
+
+	lastCalledAt = Date.now()
+
+	if (
+		message === lastMessage &&
+		Date.now() - lastCalledAt < THROTTLE_THRESHOLD_MS
+	) {
+		return
+	}
+
+	lastMessage = message
+
+	// eslint-disable-next-line no-console
+	console[level](message)
+}

--- a/src/lib/throttledLog.ts
+++ b/src/lib/throttledLog.ts
@@ -7,7 +7,7 @@ let lastCalledAt = 0
  * Logs a message. If the message is identical the immediate previous logged
  * message and that message was logged within 5 seconds of the current call, the
  * log is ignored. This throttle behavior prevents identical messages from
- * flodding the console.
+ * flooding the console.
  *
  * @param message - A message to log.
  * @param config - Configuration for the log.

--- a/test/__testutils__/testInvalidRefRetry.ts
+++ b/test/__testutils__/testInvalidRefRetry.ts
@@ -171,8 +171,11 @@ export const testInvalidRefRetry = (args: TestInvalidRefRetryArgs): void => {
 	it("throttles log", async (ctx) => {
 		const client = createTestClient({ ctx })
 		const badRef = ctx.mock.api.ref().ref
+		const queryResponse = ctx.mock.api.query({
+			documents: [ctx.mock.value.document()],
+		})
 
-		mockPrismicRestAPIV2({ ctx })
+		mockPrismicRestAPIV2({ ctx, queryResponse })
 
 		const endpoint = new URL(
 			"documents/search",


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

**Resolves**: N/A

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR prevents the client from logging its retry message many times in succession. The retry message is printed when an invalid or expired ref is tried.

The logger's history is tracked at the module level and will be shared across multiple clients.

The history **will not be shared across multiple processes**, such as during the different stages of a Next.js build. Still, this PR will reduce the total number of logs.

This PR also adds a `[@prismicio/client]` prefix to the retry message, consistent with the client's other logged messages.


### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

This is an example log when building a Next.js website that has a cached expired ref.

#### Before

```
$ npm run build

> nextjs-starter-prismic-minimal@0.1.0 build
> next build

   ▲ Next.js 15.1.6

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types
   Collecting page data  ..The ref (Z7zeQREAACIAd_Dg) was expired. Now retrying with the latest master ref (Z_bKXBEAACMA-ETo). If you were previewing content, the response will not include draft content.
 ✓ Collecting page data
The ref (Z7zeQREAACIAd_Dg) was expired. Now retrying with the latest master ref (Z_bKXBEAACMA-ETo). If you were previewing content, the response will not include draft content.
The ref (Z7zeQREAACIAd_Dg) was expired. Now retrying with the latest master ref (Z_bKXBEAACMA-ETo). If you were previewing content, the response will not include draft content.
The ref (Z7zeQREAACIAd_Dg) was expired. Now retrying with the latest master ref (Z_bKXBEAACMA-ETo). If you were previewing content, the response will not include draft content.
The ref (Z7zeQREAACIAd_Dg) was expired. Now retrying with the latest master ref (Z_bKXBEAACMA-ETo). If you were previewing content, the response will not include draft content.
The ref (Z7zeQREAACIAd_Dg) was expired. Now retrying with the latest master ref (Z_bKXBEAACMA-ETo). If you were previewing content, the response will not include draft content.
The ref (Z7zeQREAACIAd_Dg) was expired. Now retrying with the latest master ref (Z_bKXBEAACMA-ETo). If you were previewing content, the response will not include draft content.
 ✓ Generating static pages (9/9)
 ✓ Collecting build traces
 ✓ Finalizing page optimization
```

#### After

```
$ npm run build

> nextjs-starter-prismic-minimal@0.1.0 build
> next build

   ▲ Next.js 15.1.6

   Creating an optimized production build ...
 ✓ Compiled successfully
 ✓ Linting and checking validity of types
   Collecting page data  ...[@prismicio/client] The ref (Z7zeQREAACIAd_Dg) was expired. Now retrying with the latest master ref (Z_bKXBEAACMA-ETo). If you were previewing content, the response will not include draft content.
 ✓ Collecting page data
[@prismicio/client] The ref (Z7zeQREAACIAd_Dg) was expired. Now retrying with the latest master ref (Z_bKXBEAACMA-ETo). If you were previewing content, the response will not include draft content.
 ✓ Generating static pages (9/9)
 ✓ Collecting build traces
 ✓ Finalizing page optimization
```

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

1. In a Next.js Prismic website, delete the `.next` folder, which includes the `fetch()` cache.
2. Build the Next.js website.
3. Publish a change to the Prismic repo.
4. Rebuild the Next.js website. Notice the logs.

Perform the above steps once with the latest published version, then again with this PR.

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
