### PR TITLE
feat: support content relationship v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 			},
 			"devDependencies": {
 				"@prismicio/mock": "0.7.1",
-				"@prismicio/types-internal": "^3.8.0",
+				"@prismicio/types-internal": "^3.11.2",
 				"@size-limit/preset-small-lib": "^11.2.0",
 				"@trivago/prettier-plugin-sort-imports": "^4.3.0",
 				"@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -1483,9 +1483,9 @@
 			}
 		},
 		"node_modules/@prismicio/types-internal": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-3.8.0.tgz",
-			"integrity": "sha512-1o7pumA1gp/84dxh9a2hw4DFvPtmz3GnGFgKYQUUOUecGkzhEDL43AQG3FfsYYgnoM4KSXrLG0QF1fEkzoMosA==",
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@prismicio/types-internal/-/types-internal-3.13.0.tgz",
+			"integrity": "sha512-IdBjfbkABN/djQoDHWRS332NQvIbi1ZHYx7UdO+EPpmlgRKcf8QWRfEWvDUr01KQZp3jImrFhLJzIOaVBcSKmw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 	},
 	"devDependencies": {
 		"@prismicio/mock": "0.7.1",
-		"@prismicio/types-internal": "^3.8.0",
+		"@prismicio/types-internal": "^3.11.2",
 		"@size-limit/preset-small-lib": "^11.2.0",
 		"@trivago/prettier-plugin-sort-imports": "^4.3.0",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/src/types/model/contentRelationship.ts
+++ b/src/types/model/contentRelationship.ts
@@ -2,13 +2,38 @@ import type { CustomTypeModelFieldType } from "./types"
 
 import type { CustomTypeModelLinkSelectType } from "./link"
 
+type GroupLevel2 = {
+	id: string
+	fields: ReadonlyArray<string>
+}
+
+type CustomTypeLevel2 = {
+	id: string
+	fields: ReadonlyArray<string | GroupLevel2>
+}
+
+type GroupLevel1 = {
+	id: string
+	fields: ReadonlyArray<string | ContentRelationshipLevel1>
+}
+
+type ContentRelationshipLevel1 = {
+	id: string
+	customtypes: ReadonlyArray<string | CustomTypeLevel2>
+}
+
+type CustomTypeLevel1 = {
+	id: string
+	fields: ReadonlyArray<string | GroupLevel1 | ContentRelationshipLevel1>
+}
+
 /**
  * A content relationship custom type field.
  *
  * More details: {@link https://prismic.io/docs/content-relationship}
  */
 export interface CustomTypeModelContentRelationshipField<
-	CustomTypeIDs extends string = string,
+	CustomTypeIDs extends string | CustomTypeLevel1 = string | CustomTypeLevel1,
 	Tags extends string = string,
 > {
 	type: typeof CustomTypeModelFieldType.Link

--- a/test/types/customType-contentRelationship.types.ts
+++ b/test/types/customType-contentRelationship.types.ts
@@ -53,6 +53,67 @@ expectType<prismic.CustomTypeModelContentRelationshipField>({
 })
 
 /**
+ * Supports simple data linking in optional `customtypes` property.
+ */
+expectType<prismic.CustomTypeModelContentRelationshipField>({
+	type: prismic.CustomTypeModelFieldType.Link,
+	config: {
+		label: "CR-1",
+		select: prismic.CustomTypeModelLinkSelectType.Document,
+		customtypes: [{ id: "custom-type", fields: ["field-1", "field-2"] }],
+	},
+})
+
+/**
+ * Supports complex data linking in optional `customtypes` property.
+ */
+expectType<prismic.CustomTypeModelContentRelationshipField>({
+	type: prismic.CustomTypeModelFieldType.Link,
+	config: {
+		label: "CR-1",
+		select: prismic.CustomTypeModelLinkSelectType.Document,
+		customtypes: [
+			{
+				id: "custom-type-1",
+				fields: [
+					"field-1",
+					{
+						id: "group-1",
+						fields: [
+							"field-1",
+							{
+								id: "CR-2",
+								customtypes: [
+									{
+										id: "custom-type-2",
+										fields: [
+											"field-1",
+											{ id: "group-2", fields: ["field-1", "field-2"] },
+										],
+									},
+								],
+							},
+						],
+					},
+					{
+						id: "CR-2",
+						customtypes: [
+							{
+								id: "custom-type-2",
+								fields: [
+									"field-1",
+									{ id: "group-2", fields: ["field-1", "field-2"] },
+								],
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+})
+
+/**
  * Supports custom `customtypes` values.
  */
 expectType<prismic.CustomTypeModelContentRelationshipField<"foo">>({


### PR DESCRIPTION
Resolves: [DT-2712](https://linear.app/prismic/issue/DT-2712/m-aadev-in-sm-my-generated-types-are-still-working-with-new-content)

### Description

This PR adds support for data fetching defined in the `customtypes` property of the content relationship field config. 

### Checklist

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
