### PR TITLE
remove migrationAPIKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [8.0.0-alpha.0](https://github.com/prismicio/prismic-client/compare/v7.18.0...v8.0.0-alpha.0) (2025-07-22)
+
 ## [7.18.0](https://github.com/prismicio/prismic-client/compare/v7.18.0-alpha.0...v7.18.0) (2025-06-24)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@prismicio/client",
-	"version": "7.18.0",
+	"version": "8.0.0-alpha.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@prismicio/client",
-			"version": "7.18.0",
+			"version": "8.0.0-alpha.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"imgix-url-builder": "^0.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@prismicio/client",
-	"version": "7.18.0",
+	"version": "8.0.0-alpha.0",
 	"description": "The official JavaScript + TypeScript client library for Prismic",
 	"keywords": [
 		"typescript",

--- a/src/WriteClient.ts
+++ b/src/WriteClient.ts
@@ -160,18 +160,6 @@ export type CreateAssetParams = {
 }
 
 /**
- * Prismic Migration API demo keys.
- */
-const MIGRATION_API_DEMO_KEYS = [
-	"cSaZlfkQlF9C6CEAM2Del6MNX9WonlV86HPbeEJL",
-	"pZCexCajUQ4jriYwIGSxA1drZrFxDyFf1S0D1K0P",
-	"Yc0mfrkGDw8gaaGKTrzwC3QUZDajv6k73DA99vWN",
-	"ySzSEbVMAb5S1oSCQfbVG4mbh9Cb8wlF7BCvKI0L",
-	"g2DA3EKWvx8uxVYcNFrmT5nJpon1Vi9V4XcOibJD",
-	"CCNIlI0Vz41J66oFwsHUXaZa6NYFIY6z7aDF62Bc",
-]
-
-/**
  * Configuration for clients that determine how content is queried.
  */
 export type WriteClientConfig = {
@@ -179,15 +167,6 @@ export type WriteClientConfig = {
 	 * A Prismic write token that allows writing content to the repository.
 	 */
 	writeToken: string
-
-	/**
-	 * A Prismic Migration API key that allows working with the Migration API.
-	 *
-	 * @remarks
-	 * If no key is provided, the client will use one of the demo key available
-	 * which has stricter rate limiting rules enforced.
-	 */
-	migrationAPIKey?: string
 
 	/**
 	 * The Prismic Asset API endpoint.
@@ -222,7 +201,6 @@ export class WriteClient<
 	TDocuments extends PrismicDocument = PrismicDocument,
 > extends Client<TDocuments> {
 	writeToken: string
-	migrationAPIKey: string
 
 	assetAPIEndpoint = "https://asset-api.prismic.io/"
 	migrationAPIEndpoint = "https://migration.prismic.io/"
@@ -246,16 +224,11 @@ export class WriteClient<
 
 		if (typeof globalThis.window !== "undefined") {
 			console.warn(
-				`[@prismicio/client] Prismic write client appears to be running in a browser environment. This is not recommended as it exposes your write token and Migration API key. Consider using Prismic write client in a server environment only, preferring the regular client for browser environement. For more details, see ${devMsg("avoid-write-client-in-browser")}`,
+				`[@prismicio/client] Prismic write client appears to be running in a browser environment. This is not recommended as it exposes your write token. Consider using Prismic write client in a server environment only, preferring the regular client for browser environment. For more details, see ${devMsg("avoid-write-client-in-browser")}`,
 			)
 		}
 
 		this.writeToken = options.writeToken
-		this.migrationAPIKey =
-			options.migrationAPIKey ||
-			MIGRATION_API_DEMO_KEYS[
-				Math.floor(Math.random() * MIGRATION_API_DEMO_KEYS.length)
-			]
 
 		if (options.assetAPIEndpoint) {
 			this.assetAPIEndpoint = `${options.assetAPIEndpoint}/`
@@ -909,7 +882,6 @@ export class WriteClient<
 					"content-type": "application/json",
 					repository: this.repositoryName,
 					authorization: `Bearer ${this.writeToken}`,
-					"x-api-key": this.migrationAPIKey,
 				},
 			},
 		}

--- a/test/__testutils__/mockPrismicMigrationAPI.ts
+++ b/test/__testutils__/mockPrismicMigrationAPI.ts
@@ -15,7 +15,6 @@ type MockPrismicMigrationAPIArgs = {
 	ctx: TestContext
 	client: WriteClient
 	writeToken?: string
-	migrationAPIKey?: string
 	requiredHeaders?: Record<string, string>
 	existingDocuments?: (PostDocumentResult | PrismicDocument)[] | number
 	newDocuments?: { id: string; masterLanguageDocumentID?: string }[]
@@ -34,7 +33,6 @@ export const mockPrismicMigrationAPI = (
 	const repositoryName = args.client.repositoryName
 	const migrationAPIEndpoint = args.client.migrationAPIEndpoint
 	const writeToken = args.writeToken || args.client.writeToken
-	const migrationAPIKey = args.migrationAPIKey || args.client.migrationAPIKey
 
 	const documentsDatabase: Record<
 		string,
@@ -88,7 +86,6 @@ export const mockPrismicMigrationAPI = (
 			async (req, res, ctx) => {
 				if (
 					req.headers.get("authorization") !== `Bearer ${writeToken}` ||
-					req.headers.get("x-api-key") !== migrationAPIKey ||
 					req.headers.get("repository") !== repositoryName
 				) {
 					return res(ctx.status(403), ctx.json({ Message: "forbidden" }))
@@ -129,7 +126,6 @@ export const mockPrismicMigrationAPI = (
 			async (req, res, ctx) => {
 				if (
 					req.headers.get("authorization") !== `Bearer ${writeToken}` ||
-					req.headers.get("x-api-key") !== migrationAPIKey ||
 					req.headers.get("repository") !== repositoryName
 				) {
 					return res(ctx.status(403), ctx.json({ Message: "forbidden" }))

--- a/test/writeClient.test.ts
+++ b/test/writeClient.test.ts
@@ -51,13 +51,3 @@ it("uses provided Migration API endpoint and adds `/` suffix", () => {
 
 	expect(client.migrationAPIEndpoint).toBe("https://example.com/")
 })
-
-it("uses provided Migration API key", () => {
-	const client = prismic.createWriteClient("qwerty", {
-		fetch: vi.fn(),
-		writeToken: "xxx",
-		migrationAPIKey: "yyy",
-	})
-
-	expect(client.migrationAPIKey).toBe("yyy")
-})


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->
https://linear.app/prismic/issue/DT-2737/m-aadev-i-can-use-migration-api-client-without-a-key-management

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
- remove migrationAPIKey from write client
- fix mocks and tests
- publish major alpha

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
