### PR TITLE
fix: rename `isFilled.integrationField` to `isFilled.integration`

### DIFF
--- a/src/helpers/isFilled.ts
+++ b/src/helpers/isFilled.ts
@@ -258,16 +258,21 @@ export const table = isNonNullish as (
  *
  * @returns `true` if `field` is filled, `false` otherwise.
  */
-export const integrationField = isNonNullish as <
+export const integration = isNonNullish as <
 	Data extends Record<string, unknown>,
 >(
 	field: IntegrationField<Data> | null | undefined,
 ) => field is IntegrationField<Data, "filled">
 /**
+ * @deprecated Renamed to `integration`.
+ */
+// TODO: Remove when we remove support for deprecated `integrationField` export.
+export const integrationField = integration
+/**
  * @deprecated Renamed to `integrationField`.
  */
 // TODO: Remove when we remove support for deprecated `integrationFields` export.
-export const integrationFields = integrationField
+export const integrationFields = integration
 
 /**
  * Determines if a repeatable field has at least one item.

--- a/test/helpers-isFilled.test.ts
+++ b/test/helpers-isFilled.test.ts
@@ -87,13 +87,16 @@ it("image thumbnail", () => {
 	).toBe(true)
 })
 
-it("integration fields", (ctx) => {
-	expect(isFilled.integrationField(null)).toBe(false)
-	expect(isFilled.integrationField(undefined)).toBe(false)
-	expect(isFilled.integrationField(ctx.mock.value.integration())).toBe(true)
+it("integration", (ctx) => {
+	expect(isFilled.integration(null)).toBe(false)
+	expect(isFilled.integration(undefined)).toBe(false)
+	expect(isFilled.integration(ctx.mock.value.integration())).toBe(true)
 })
-it("aliases integrationFields to integrationField", () => {
-	expect(isFilled.integrationField).toBe(isFilled.integrationField)
+it("aliases integrationField to integration", () => {
+	expect(isFilled.integrationField).toBe(isFilled.integration)
+})
+it("aliases integrationFields to integration", () => {
+	expect(isFilled.integrationFields).toBe(isFilled.integration)
 })
 
 it("key text", (ctx) => {

--- a/test/types/helpers-isFilled.types.ts
+++ b/test/types/helpers-isFilled.types.ts
@@ -565,14 +565,14 @@ type EmbedData = prismic.VideoOEmbed & { foo: string }
 }
 
 /**
- * Integration fields
+ * Integration
  */
 
 type IntegrationFieldDefault = Record<string, unknown>
 
 // Default
 ;(value: prismic.IntegrationField) => {
-	if (prismic.isFilled.integrationField(value)) {
+	if (prismic.isFilled.integration(value)) {
 		expectType<
 			TypeEqual<
 				prismic.IntegrationField<IntegrationFieldDefault, "filled">,
@@ -605,7 +605,7 @@ type IntegrationFieldData = { foo: string }
 
 // With data
 ;(value: prismic.IntegrationField<IntegrationFieldData>) => {
-	if (prismic.isFilled.integrationField(value)) {
+	if (prismic.isFilled.integration(value)) {
 		expectType<
 			TypeEqual<
 				prismic.IntegrationField<IntegrationFieldData, "filled">,


### PR DESCRIPTION
Resolves: N/A

### Description

This PR renames `isFilled.integrationField` to `isFilled.integration` to match the naming convention used for other field types in the codebase. The old names (`integrationField` and `integrationFields`) are kept as deprecated aliases to maintain backward compatibility.

The change follows the existing deprecation pattern used throughout the codebase, with proper `@deprecated` JSDoc comments and TODO notes for future removal.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

```ts
isFilled.integration(field)
```

### How to QA [^1]

1. Verify that `isFilled.integration()` works correctly for checking integration fields
2. Verify that the deprecated `isFilled.integrationField()` still works (aliased to `integration`)
3. Verify that the deprecated `isFilled.integrationFields()` still works (aliased to `integration`)

🚀

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.