### PR TITLE
fix retry after 429

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -72,14 +72,14 @@ export const GET_ALL_QUERY_DELAY = 500
  *
  * The API allows up to 200 requests per second.
  */
-const DEFUALT_RETRY_AFTER_MS = 1000
+const DEFAULT_RETRY_AFTER_MS = 1000
 
 /**
- * The maximum number of attemps to retry a query with an invalid ref. We allow
+ * The maximum number of attempts to retry a query with an invalid ref. We allow
  * multiple attempts since each attempt may use a different (and possibly
- * invalid) ref. Capping the number of attemps prevents infinite loops.
+ * invalid) ref. Capping the number of attempts prevents infinite loops.
  */
-const MAX_INVALID_REF_RETRY_ATTEMPS = 3
+const MAX_INVALID_REF_RETRY_ATTEMPTS = 3
 
 /**
  * Extracts one or more Prismic document types that match a given Prismic
@@ -1721,7 +1721,7 @@ export class Client<
 				!(
 					error instanceof RefNotFoundError || error instanceof RefExpiredError
 				) ||
-				attemptCount >= MAX_INVALID_REF_RETRY_ATTEMPS - 1
+				attemptCount >= MAX_INVALID_REF_RETRY_ATTEMPTS - 1
 			) {
 				throw error
 			}
@@ -1840,8 +1840,8 @@ export class Client<
 			case 429: {
 				const parsedRetryAfter = Number(res.headers.get("retry-after"))
 				const delay = Number.isNaN(parsedRetryAfter)
-					? DEFUALT_RETRY_AFTER_MS
-					: parsedRetryAfter
+					? DEFAULT_RETRY_AFTER_MS
+					: parsedRetryAfter * 1000
 
 				return await new Promise((resolve, reject) => {
 					setTimeout(async () => {


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->
https://linear.app/prismic/issue/DT-2830/migration-api-client-fix-the-retry-delay-to-be-in-second-not-ms

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
