### PR TITLE
add x-client headers to access migration api

### DIFF
--- a/src/WriteClient.ts
+++ b/src/WriteClient.ts
@@ -32,6 +32,8 @@ import { InvalidDataError } from "./errors/InvalidDataError"
 import { NotFoundError } from "./errors/NotFoundError"
 import { PrismicError } from "./errors/PrismicError"
 
+import { version } from "../package.json"
+
 import { Client } from "./Client"
 import type { ClientConfig, FetchParams } from "./Client"
 import type { Migration } from "./Migration"
@@ -769,6 +771,8 @@ export class WriteClient<
 			}),
 			headers: {
 				"content-type": "application/json",
+				"x-client": "@prismicio/client",
+				"x-client-version": version,
 			},
 		})
 		switch (response.status) {
@@ -813,6 +817,8 @@ export class WriteClient<
 			}),
 			headers: {
 				"content-type": "application/json",
+				"x-client": "@prismicio/client",
+				"x-client-version": version,
 			},
 		})
 		switch (response.status) {

--- a/test/writeClient-createDocument.test.ts
+++ b/test/writeClient-createDocument.test.ts
@@ -100,6 +100,40 @@ it.concurrent("supports custom headers", async (ctx) => {
 	ctx.expect.assertions(2)
 })
 
+it.concurrent("includes client identification headers", async (ctx) => {
+	const client = createTestWriteClient({ ctx })
+
+	// Import the version dynamically to avoid hardcoding
+	const { version } = await import("../package.json")
+
+	const requiredHeaders = {
+		"x-client": "@prismicio/client",
+		"x-client-version": version,
+	}
+	const newDocument = { id: "foo" }
+
+	mockPrismicMigrationAPI({
+		ctx,
+		client,
+		requiredHeaders,
+		newDocuments: [newDocument],
+	})
+
+	// @ts-expect-error - testing purposes
+	const { id } = await client.createDocument(
+		{
+			type: "type",
+			uid: "uid",
+			lang: "lang",
+			data: {},
+		},
+		"Foo",
+	)
+
+	ctx.expect(id).toBe(newDocument.id)
+	ctx.expect.assertions(3)
+})
+
 it.concurrent("respects unknown rate limit", async (ctx) => {
 	const client = createTestWriteClient({ ctx })
 


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->
https://linear.app/prismic/issue/DT-2838/migration-api-client-add-a-header-to-inform-us-prismic-who-is-using

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
we want to track if the migration api is used via our sdk or directly - so we're adding a couple of headers when making requests to the migration api

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
