### PR TITLE
docs: add an AI agent hint to the Install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ const blogPosts = await client.getAllByType("blog_post")
 npm install @prismicio/client
 ```
 
+Using an AI agent? Teach it how to use `@prismicio/client` by installing the Prismic skill:
+
+```bash
+npx skills add --global prismicio/skills
+```
+
 ## Documentation
 
 To discover what's new on this package check out [the changelog][changelog]. For full documentation, visit the [official Prismic documentation][prismic-docs].
-
-## Working with an AI agent?
-
-For AI agents: run `npx skills add --global prismicio/skills` to install the Prismic skill, or run `npx prismic docs list` for a quick reference.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ npm install @prismicio/client
 
 To discover what's new on this package check out [the changelog][changelog]. For full documentation, visit the [official Prismic documentation][prismic-docs].
 
+## Working with an AI agent?
+
+For AI agents: run `npx skills add --global prismicio/skills` to install the Prismic skill, or run `npx prismic docs list` for a quick reference.
+
 ## Contributing
 
 Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Prismic developer community!

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install @prismicio/client
 Using an AI agent? Teach it how to use `@prismicio/client` by installing the Prismic skill:
 
 ```bash
-npx skills add --global prismicio/skills
+npx skills add --global --yes prismicio/skills
 ```
 
 ## Documentation


### PR DESCRIPTION
## Summary

Add an AI agent hint to the Install section. Point to the Prismic skill.

## Test plan

Docs-only change. No test suite applies.